### PR TITLE
fix(publish): Make dependencies jar for Maven build leaner

### DIFF
--- a/bundles/org.bonitasoft.bonita2bpmn/src/org/bonitasoft/bonita2bpmn/transfo/CustomRectilinearRouter.java
+++ b/bundles/org.bonitasoft.bonita2bpmn/src/org/bonitasoft/bonita2bpmn/transfo/CustomRectilinearRouter.java
@@ -24,7 +24,6 @@ import org.eclipse.draw2d.geometry.PrecisionPoint;
 import org.eclipse.draw2d.geometry.PrecisionRectangle;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Vector;
-import org.eclipse.gmf.runtime.common.core.util.StringStatics;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.BaseSlidableAnchor;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.IOvalAnchorableFigure;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.IPolygonAnchorableFigure;
@@ -295,12 +294,12 @@ public class CustomRectilinearRouter extends ObliqueRouter {
                             lastRemovedFromSource.y);
                 }
             } else if ((conn.getSourceAnchor() instanceof BaseSlidableAnchor
-                    && StringStatics.BLANK.equals(((BaseSlidableAnchor) conn
+                    && "".equals(((BaseSlidableAnchor) conn
                             .getSourceAnchor()).getTerminal())
                     && (conn
-                            .getTargetAnchor() instanceof BaseSlidableAnchor && StringStatics.BLANK
-                                    .equals(((BaseSlidableAnchor) conn.getTargetAnchor())
-                                            .getTerminal())))) {
+                            .getTargetAnchor() instanceof BaseSlidableAnchor
+                            && "".equals(((BaseSlidableAnchor) conn.getTargetAnchor())
+                                    .getTerminal())))) {
                 /*
                  * This a special case for old diagrams with rectilinear connections routed by
                  * the old router to look good with the new router

--- a/bundles/org.bonitasoft.bpm.plugin-dependencies/pom.xml
+++ b/bundles/org.bonitasoft.bpm.plugin-dependencies/pom.xml
@@ -40,7 +40,15 @@
             <configuration>
               <excludes>META-INF/*.SF,META-INF/*.DSA,META-INF/*.RSA</excludes>
               <excludeTransitive>true</excludeTransitive>
-              <excludeArtifactIds>org.eclipse.emf.ecore,org.eclipse.emf.ecore.xmi,org.eclipse.emf.common,org.osgi.service.prefs</excludeArtifactIds>
+              <!-- Exclude dependencies already in pom dependencies (exclude recursively the P2 equivalent), and also OCL which we do not really need -->
+              <!-- Do not exclude: org.eclipse.core.runtime and its dependencies, for which we need the correct version not published as maven,
+                   org.eclipse.ocl required by Edapt -->
+              <excludeArtifactIds>org.eclipse.emf.ecore,org.eclipse.emf.ecore.xmi,org.eclipse.emf.common,org.eclipse.core.resources,
+                javax.annotation,javax.inject,org.eclipse.core.runtime.compatibility.auth,
+                org.eclipse.core.expressions,org.eclipse.core.filesystem,org.osgi.service.prefs,org.osgi.service.log,org.osgi.service.application,
+                org.eclipse.m2e.maven.runtime,
+                org.eclipse.ocl.common,org.eclipse.ocl.ecore,lpg.runtime.java</excludeArtifactIds>
+              <!-- Also exclude test plugins -->
               <excludeGroupIds>junit,org.mockito,org.hamcrest</excludeGroupIds>
               <outputDirectory>${project.build.directory}/dependency</outputDirectory>
               <overWriteReleases>false</overWriteReleases>

--- a/bundles/org.bonitasoft.gmf.plugin-dependencies/pom.xml
+++ b/bundles/org.bonitasoft.gmf.plugin-dependencies/pom.xml
@@ -31,9 +31,28 @@
             </goals>
             <phase>package</phase>
             <configuration>
-              <excludes>META-INF/*.SF,META-INF/*.DSA,META-INF/*.RSA</excludes>
+              <!-- We need to load ui-related classes, but not the OS-specific libs, nor the logos... -->
+              <excludes>META-INF/*.SF,META-INF/*.DSA,META-INF/*.RSA,rosemodel/*,*.so,*.dll,*.jnilib,*.png</excludes>
               <excludeTransitive>true</excludeTransitive>
-              <excludeArtifactIds>org.eclipse.emf.ecore,org.eclipse.emf.ecore.xmi,org.eclipse.emf.common,org.eclipse.core.runtime,org.eclipse.equinox.app,org.eclipse.equinox.common,org.eclipse.equinox.preferences,org.eclipse.equinox.registry,org.eclipse.osgi,org.osgi.service.prefs,org.osgi.service.log,org.osgi.service.application</excludeArtifactIds>
+              <!-- Exclude dependencies already in pom dependencies (exclude recursively the P2 equivalent), and UI stuff. -->
+              <!-- Do not exclude: org.eclipse.gmf.runtime.diagram.ui used for constants and org.eclipse.gmf.runtime.draw2d.ui,org.eclipse.gmf.runtime.gef.ui for some computations
+                   and their required dependencies org.eclipse.gef,org.eclipse.draw2d,org.eclipse.swt,org.eclipse.swt.<fragment>,org.eclipse.ui.workbench-->
+              <excludeArtifactIds>org.eclipse.emf.ecore,org.eclipse.emf.ecore.xmi,org.eclipse.emf.common,org.eclipse.core.runtime,org.eclipse.core.resources,
+                javax.annotation,javax.inject,org.eclipse.osgi,org.eclipse.equinox.common,org.eclipse.core.jobs,org.eclipse.equinox.registry,org.eclipse.equinox.preferences,org.eclipse.core.contenttype,org.eclipse.core.runtime.compatibility.auth,org.eclipse.equinox.app,
+                org.eclipse.core.expressions,org.eclipse.core.filesystem,org.osgi.service.prefs,org.osgi.service.log,org.osgi.service.application,
+                org.eclipse.m2e.maven.runtime,
+                org.eclipse.gmf.runtime.common.ui,org.eclipse.gmf.runtime.common.ui.action,org.eclipse.gmf.runtime.common.ui.services,org.eclipse.gmf.runtime.common.ui.services.action,org.eclipse.gmf.runtime.draw2d.ui.render,
+                org.eclipse.gmf.runtime.emf.commands.core,org.eclipse.gmf.runtime.emf.core,org.eclipse.gmf.runtime.emf.clipboard.core,org.eclipse.emf.workspace,org.eclipse.emf.ecore.edit,org.eclipse.gmf.runtime.emf.type.core,
+                org.eclipse.emf.validation,org.eclipse.emf.edit,org.eclipse.emf.transaction,org.eclipse.emf.ecore.change,
+                org.eclipse.core.databinding,org.eclipse.core.databinding.observable,org.eclipse.core.databinding.property,org.eclipse.help,org.eclipse.debug.core,org.eclipse.text,org.eclipse.compare.core,org.eclipse.urischeme,org.eclipse.core.variables,org.eclipse.core.commands,
+                org.eclipse.e4.ui.swt.gtk,org.eclipse.e4.ui.swt.win32,org.eclipse.e4.ui.workbench,org.eclipse.e4.ui.workbench.swt,org.eclipse.e4.ui.workbench.renderers,org.eclipse.e4.ui.workbench.renderers.swt,org.eclipse.e4.ui.workbench.addons.swt,org.eclipse.e4.ui.model.workbench,org.eclipse.e4.emf.xpath,
+                org.eclipse.e4.ui.bindings,org.eclipse.e4.ui.dialogs,org.eclipse.e4.ui.services,org.eclipse.e4.ui.widgets,org.eclipse.e4.ui.di,org.eclipse.e4.ui.css.core,org.eclipse.e4.ui.css.swt,org.eclipse.e4.ui.css.swt.theme,org.eclipse.e4.ui.workbench3,
+                org.eclipse.e4.core.services,org.eclipse.e4.core.di,org.eclipse.e4.core.di.annotations,org.eclipse.e4.core.di.extensions,org.eclipse.e4.core.commands,org.eclipse.e4.core.contexts,
+                org.eclipse.ui,org.eclipse.ui.dialogs,org.eclipse.ui.ide,org.eclipse.ui.console,org.eclipse.ui.views,org.eclipse.ui.editors,org.eclipse.ui.workbench.texteditor,org.eclipse.ui.views.properties.tabbed,org.eclipse.ui.forms,
+                org.apache.xmlgraphics,org.eclipse.jface,org.eclipse.jface.text,org.eclipse.team.core,org.osgi.services,
+                org.apache.batik.css,org.apache.batik.util,org.apache.batik.constants,org.apache.batik.i18n,org.apache.commons.jxpath,org.apache.commons.io,org.apache.commons.logging,org.apache.felix.scr,com.ibm.icu,
+                com.sun.jna,com.sun.jna.platform</excludeArtifactIds>
+              <!-- Also exclude test plugins -->
               <excludeGroupIds>junit,org.mockito,org.hamcrest,org.eclipse.equinox</excludeGroupIds>
               <outputDirectory>${project.build.directory}/dependency</outputDirectory>
               <overWriteReleases>false</overWriteReleases>


### PR DESCRIPTION
Exclude dependencies already in pom dependencies (exclude recursively the P2 equivalent),
and UI stuff, and OCL stuff.

Relates to [DEV-403](https://bonitasoft.atlassian.net/browse/DEV-403)


[DEV-403]: https://bonitasoft.atlassian.net/browse/DEV-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ