### PR TITLE
fix(callActivity): Map groovy expression to data

### DIFF
--- a/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/process/builder/EngineFlowElementBuilder.java
+++ b/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/process/builder/EngineFlowElementBuilder.java
@@ -511,7 +511,8 @@ public class EngineFlowElementBuilder extends AbstractProcessBuilder {
         } else {
             final List<EObject> referencedElements = mapping.getProcessSource().getReferencedElements();
             String type = LeftOperand.TYPE_DATA;
-            if (!referencedElements.isEmpty()) {
+            if (!referencedElements.isEmpty()
+                    && Objects.equals(ExpressionConstants.VARIABLE_TYPE, mapping.getProcessSource().getType())) {
                 type = getLeftOperandTypeForData(referencedElements.get(0));
             }
             leftOperandbuilder.setType(type);


### PR DESCRIPTION
When the target data type is unknown, use the DATA type if the expression is a Groovy Script instead of a Business Data type.

Closes [STUDIO-4490](https://bonitasoft.atlassian.net/browse/STUDIO-4490)


[STUDIO-4490]: https://bonitasoft.atlassian.net/browse/STUDIO-4490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ