### PR TITLE
feat(barBuilder): set the missing tmp pom file path

### DIFF
--- a/bundles/org.bonitasoft.bonita2bar/META-INF/MANIFEST.MF
+++ b/bundles/org.bonitasoft.bonita2bar/META-INF/MANIFEST.MF
@@ -67,4 +67,5 @@ Export-Package: org.bonitasoft.bonita2bar,
  org.bonitasoft.bonita2bar.process,
  org.bonitasoft.bonita2bar.process.builder,
  org.bonitasoft.bonita2bar.process.expression,
+ org.bonitasoft.bonita2bar.process.pomgen,
  org.bonitasoft.bonita2bar.resources

--- a/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/process/pomgen/ProcessPom.java
+++ b/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/process/pomgen/ProcessPom.java
@@ -51,7 +51,9 @@ public class ProcessPom implements Closeable {
         }
         var reader = new MavenXpp3Reader();
         try (var fileReader = new FileReader(pom)) {
-            return reader.read(fileReader);
+            var pomModel = reader.read(fileReader);
+            pomModel.setPomFile(pom);
+            return pomModel;
         }
     }
 


### PR DESCRIPTION
Fix the following issues : 

- [x] set the missing tmp pom file path

See also [PR-Display maven dependency tree for processes](https://github.com/bonitasoft/bonita-studio-sp/pull/3728)
