### PR TITLE
feat(bar): Possibility to build a jarless BAR

### DIFF
--- a/bundles/org.bonitasoft.bonita2bar/pom.xml
+++ b/bundles/org.bonitasoft.bonita2bar/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>org.bonitasoft.engine</groupId>
       <artifactId>bonita-business-archive</artifactId>
-      <version>1.0.0</version>
+      <version>1.1.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/classpath/CustomGroovyArtifactProvider.java
+++ b/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/classpath/CustomGroovyArtifactProvider.java
@@ -160,6 +160,9 @@ public class CustomGroovyArtifactProvider implements BarArtifactProvider {
     }
 
     private Set<File> collectGroovySourceFile(Path groovySource, final Pool process) throws BuildBarException {
+        if (!Files.exists(groovySource)) {
+            return Set.of();
+        }
         try (Stream<Path> walker = Files.walk(groovySource)) {
             List<Path> groovyPaths = walker.filter(Files::isRegularFile)
                     .filter(file -> file.toString().endsWith(".groovy")).toList();

--- a/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/classpath/WithoutDependencyJarsArtifactProvider.java
+++ b/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/classpath/WithoutDependencyJarsArtifactProvider.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2025 Bonitasoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2.0 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.bonitasoft.bonita2bar.classpath;
+
+import org.bonitasoft.bonita2bar.BarArtifactProvider;
+import org.bonitasoft.bonita2bar.process.pomgen.ProcessPom;
+import org.bonitasoft.bpm.model.configuration.Configuration;
+import org.bonitasoft.bpm.model.process.Pool;
+import org.bonitasoft.engine.bpm.bar.BusinessArchiveBuilder;
+
+/**
+ * While building the BAR file, tag it to indicate it will not contain dependency jars.
+ */
+public class WithoutDependencyJarsArtifactProvider implements BarArtifactProvider {
+
+    @Override
+    public void build(BusinessArchiveBuilder builder, Pool process, ProcessPom pomAccess, Configuration configuration) {
+        builder.withoutDependencyJars();
+    }
+
+}

--- a/releng/target-platform/target-platform.target
+++ b/releng/target-platform/target-platform.target
@@ -73,7 +73,7 @@
 		        </dependencies>
 	        </location>
 	        <location includeDependencyDepth="none" includeDependencyScopes="compile,runtime,system" includeSource="true" missingManifest="generate" type="Maven">
-		        <feature id="org.bonitasoft.artifacts.model.feature" label="Bonita Artifacts Models Feature" provider-name="Bonitasoft S.A" version="1.1.2">
+		        <feature id="org.bonitasoft.artifacts.model.feature" label="Bonita Artifacts Models Feature" provider-name="Bonitasoft S.A" version="1.1.3.qualifier">
 			        <description url="https://github.com/bonitasoft/bonita-process-model">
       Bonita Artifacts Model Feature
    </description>
@@ -124,25 +124,25 @@
 			        <dependency>
 				        <groupId>org.bonitasoft.engine</groupId>
 				        <artifactId>bonita-business-archive</artifactId>
-				        <version>1.1.2</version>
+				        <version>1.1.3-SNAPSHOT</version>
 				        <type>jar</type>
 			        </dependency>
 			        <dependency>
 				        <groupId>org.bonitasoft.engine</groupId>
 				        <artifactId>bonita-common-artifacts-model</artifactId>
-				        <version>1.1.2</version>
+				        <version>1.1.3-SNAPSHOT</version>
 				        <type>jar</type>
 			        </dependency>
 			        <dependency>
 				        <groupId>org.bonitasoft.engine</groupId>
 				        <artifactId>bonita-form-mapping-model</artifactId>
-				        <version>1.1.2</version>
+				        <version>1.1.3-SNAPSHOT</version>
 				        <type>jar</type>
 			        </dependency>
 			        <dependency>
 				        <groupId>org.bonitasoft.engine</groupId>
 				        <artifactId>bonita-process-definition-model</artifactId>
-				        <version>1.1.2</version>
+				        <version>1.1.3-SNAPSHOT</version>
 				        <type>jar</type>
 			        </dependency>
 			        <dependency>


### PR DESCRIPTION
Build a bar which does not contain the dependency jars. (to be used for SCA only)

bonita-business-archive version is updated to SNAPSHOT for now. It should be updated to 1.2.0 after bonita-artifacts-model release.

Relates to [BPM-406](https://bonitasoft.atlassian.net/browse/BPM-406)

[BPM-406]: https://bonitasoft.atlassian.net/browse/BPM-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ