### PR TITLE
chore: update target platform and dependencies

### DIFF
--- a/bundles/org.bonitasoft.bonita2bar/META-INF/MANIFEST.MF
+++ b/bundles/org.bonitasoft.bonita2bar/META-INF/MANIFEST.MF
@@ -58,6 +58,7 @@ Import-Package: org.bonitasoft.engine,
  org.bonitasoft.engine.operation,
  org.bonitasoft.engine.operation.impl,
  org.bonitasoft.engine.xml.parser,
+ org.eclipse.core.resources,
  org.eclipse.core.runtime;version="[3.7.0,4.0.0)",
  org.slf4j;version="1.7.30"
 Export-Package: org.bonitasoft.bonita2bar,

--- a/bundles/org.bonitasoft.bonita2bar/pom.xml
+++ b/bundles/org.bonitasoft.bonita2bar/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>org.bonitasoft.engine</groupId>
       <artifactId>bonita-business-archive</artifactId>
-      <version>1.1.3-SNAPSHOT</version>
+      <version>${bonita-artifacts-model.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/bundles/org.bonitasoft.spec.bpmn/.classpath
+++ b/bundles/org.bonitasoft.spec.bpmn/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/org.bonitasoft.spec.bpmn/META-INF/MANIFEST.MF
+++ b/bundles/org.bonitasoft.spec.bpmn/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 9.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.omg.spec.bpmn.di,
  org.omg.spec.bpmn.di.impl,
  org.omg.spec.bpmn.di.util,

--- a/bundles/process-reader-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/bundles/process-reader-archetype/src/main/resources/archetype-resources/pom.xml
@@ -28,9 +28,9 @@
     <maven-deploy-plugin.version>${maven-deploy-version}</maven-deploy-plugin.version>
     
     <!-- Tests -->
-    <junit-jupiter-engine.version>5.7.2</junit-jupiter-engine.version>
-    <assertj-core.version>3.20.2</assertj-core.version>
-    <mockito-core.version>3.11.2</mockito-core.version>
+    <junit-jupiter-engine.version>5.12.0</junit-jupiter-engine.version>
+    <assertj-core.version>3.24.2</assertj-core.version>
+    <mockito-core.version>5.16.0</mockito-core.version>
     <logback-classic.version>1.2.13</logback-classic.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,11 +73,12 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</com
     <cyclonedx.version>2.7.9</cyclonedx.version>
     <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
-    <tycho.version>4.0.7</tycho.version>
-    <emf-ecore.version>2.27.0</emf-ecore.version>
-    <emf-common.version>2.25.0</emf-common.version>
-    <emf-xmi.version>2.16.0</emf-xmi.version>
-    <emf-edit.version>2.17.0</emf-edit.version>
+    <tycho.version>4.0.12</tycho.version>
+    <bonita-artifacts-model.version>1.2.0</bonita-artifacts-model.version>
+    <emf-ecore.version>2.37.0</emf-ecore.version>
+    <emf-common.version>2.31.0</emf-common.version>
+    <emf-xmi.version>2.38.0</emf-xmi.version>
+    <emf-edit.version>2.22.0</emf-edit.version>
     <maven-artifact.version>3.9.3</maven-artifact.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     <maven-invoker-plugin.version>3.3.0</maven-invoker-plugin.version>

--- a/releng/target-platform/target-platform.target
+++ b/releng/target-platform/target-platform.target
@@ -1,168 +1,117 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?>
-<target includeMode="feature" name="platform">
-        <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
-        <locations>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <repository location="https://download.eclipse.org/releases/2024-09"/>
-            <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.gmf.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <repository location="http://download.eclipse.org/edapt/releases/15x/150"/>
-            <unit id="org.eclipse.emf.edapt.runtime.feature.feature.group" version="0.0.0"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <repository location="https://groovy.jfrog.io/artifactory/plugins-release/e4.33/"/>
-            <unit id="org.codehaus.groovy30.feature.feature.group" version="0.0.0"/>
-        </location>
-	        <location includeDependencyDepth="infinite" includeDependencyScopes="compile,runtime,system" includeSource="true" missingManifest="generate" type="Maven">
-		        <dependencies>
-			        <dependency>
-				        <groupId>org.assertj</groupId>
-				        <artifactId>assertj-core</artifactId>
-				        <version>3.24.2</version>
-				        <type>jar</type>
-			        </dependency>
-			        <dependency>
-				        <groupId>org.mockito</groupId>
-				        <artifactId>mockito-core</artifactId>
-				        <version>4.6.1</version>
-				        <type>jar</type>
-			        </dependency>
-			        <dependency>
-				        <groupId>org.mockito</groupId>
-				        <artifactId>mockito-junit-jupiter</artifactId>
-				        <version>4.6.1</version>
-				        <type>jar</type>
-			        </dependency>
-		        </dependencies>
-	        </location>
-	        <location includeDependencyDepth="infinite" includeDependencyScopes="compile,runtime,system" includeSource="true" missingManifest="generate" type="Maven">
-
-		        <feature id="com.fasterxml.jackson.feature" label="Jackson Feature" provider-name="Bonitasoft S.A" version="2.18.3">
-			        <description url="https://github.com/bonitasoft/bonita-process-model">
-      Jackson Feature
-   </description>
-			        <copyright url="https://www.bonitasoft.com/">
-      Copyright (C) 2023 BonitaSoft S.A.
-   BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
-   </copyright>
-			        <license url="http://www.gnu.org/licenses/gpl-2.0.html">
-      This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 2.0 of the License, or
-   (at your option) any later version.
-   
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-   
-   You should have received a copy of the GNU General Public License
-   along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
-   </license>
-		        </feature>
-		        <dependencies>
-			        <dependency>
-				        <groupId>com.fasterxml.jackson.dataformat</groupId>
-				        <artifactId>jackson-dataformat-yaml</artifactId>
-				        <version>2.18.3</version>
-				        <type>jar</type>
-			        </dependency>
-		        </dependencies>
-	        </location>
-	        <location includeDependencyDepth="none" includeDependencyScopes="compile,runtime,system" includeSource="true" missingManifest="generate" type="Maven">
-		        <feature id="org.bonitasoft.artifacts.model.feature" label="Bonita Artifacts Models Feature" provider-name="Bonitasoft S.A" version="1.1.3.qualifier">
-			        <description url="https://github.com/bonitasoft/bonita-process-model">
-      Bonita Artifacts Model Feature
-   </description>
-			        <copyright url="https://www.bonitasoft.com/">
-      Copyright (C) 2023 BonitaSoft S.A.
-   BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
-   </copyright>
-			        <license url="http://www.gnu.org/licenses/gpl-2.0.html">
-      This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 2.0 of the License, or
-   (at your option) any later version.
-   
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-   
-   You should have received a copy of the GNU General Public License
-   along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
-   </license>
-		        </feature>
-		          <repositories>
-			        <repository>
-				        <id>ossrh-snapshots</id>
-				        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-			        </repository>
-		        </repositories>
-		        <dependencies>
-			        <dependency>
-				        <groupId>com.sun.activation</groupId>
-				        <artifactId>jakarta.activation</artifactId>
-				        <version>1.2.2</version>
-				        <type>jar</type>
-			        </dependency>
-			        <dependency>
-				        <groupId>com.sun.xml.bind</groupId>
-				        <artifactId>jaxb-osgi</artifactId>
-				        <version>2.3.8</version>
-				        <type>jar</type>
-			        </dependency>
-			        <dependency>
-				        <groupId>jakarta.xml.bind</groupId>
-				        <artifactId>jakarta.xml.bind-api</artifactId>
-				        <version>2.3.3</version>
-				        <type>jar</type>
-			        </dependency>
-			        <dependency>
-				        <groupId>org.bonitasoft.engine</groupId>
-				        <artifactId>bonita-business-archive</artifactId>
-				        <version>1.2.0</version>
-				        <type>jar</type>
-			        </dependency>
-			        <dependency>
-				        <groupId>org.bonitasoft.engine</groupId>
-				        <artifactId>bonita-common-artifacts-model</artifactId>
-				        <version>1.2.0</version>
-				        <type>jar</type>
-			        </dependency>
-			        <dependency>
-				        <groupId>org.bonitasoft.engine</groupId>
-				        <artifactId>bonita-form-mapping-model</artifactId>
-				        <version>1.2.0</version>
-				        <type>jar</type>
-			        </dependency>
-			        <dependency>
-				        <groupId>org.bonitasoft.engine</groupId>
-				        <artifactId>bonita-process-definition-model</artifactId>
-				        <version>1.2.0</version>
-				        <type>jar</type>
-			        </dependency>
-			        <dependency>
-				        <groupId>org.glassfish.hk2</groupId>
-				        <artifactId>osgi-resource-locator</artifactId>
-				        <version>2.4.0</version>
-				        <type>jar</type>
-			        </dependency>
-		        </dependencies>
-		        		        <instructions><![CDATA[
-Bundle-Name:           ${mvnGroupId}:${mvnArtifactId}:${mvnVersion}
-version:               ${version_cleanup;${mvnVersion}}
-Bundle-SymbolicName:   ${mvnGroupId}.${mvnArtifactId}
-Bundle-Version:        ${version}
-Import-Package:        *;resolution:=optional
-Export-Package:        *;version="${version}";-noimport:=true
-DynamicImport-Package: *
-]]></instructions>
-	        </location>
-        </locations>
+<?pde?>
+<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+<target name="platform" sequenceNumber="1741966347">
+  <locations>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.eclipse.equinox.sdk.feature.group" version="3.23.1400.v20240820-0604"/>
+      <unit id="org.eclipse.sdk.feature.group" version="4.33.0.v20240903-0618"/>
+      <unit id="org.eclipse.gmf.feature.group" version="1.16.4.202405171447"/>
+      <unit id="org.eclipse.m2e.feature.feature.group" version="2.6.2.20240828-1954"/>
+      <repository id="E2024-09" location="https://download.eclipse.org/releases/2024-09"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.eclipse.emf.edapt.runtime.feature.feature.group" version="1.5.0.202201311430"/>
+      <repository location="http://download.eclipse.org/edapt/releases/15x/150"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.codehaus.groovy30.feature.feature.group" version="5.6.0.v202501010114-e2409"/>
+      <repository location="https://groovy.jfrog.io/artifactory/plugins-release/e4.33/"/>
+    </location>
+    <location includeDependencyDepth="none" includeDependencyScopes="compile,runtime,system" includeSource="true" missingManifest="generate" type="Maven" label="BonitaArtifactsModels">
+      <feature id="org.bonitasoft.artifacts.model.feature" label="Bonita Artifacts Models Feature" provider-name="Bonitasoft S.A" version="1.2.0">
+      </feature>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun.activation</groupId>
+          <artifactId>jakarta.activation</artifactId>
+          <version>1.2.2</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-osgi</artifactId>
+          <version>2.3.8</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
+          <version>2.3.3</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.bonitasoft.engine</groupId>
+          <artifactId>bonita-business-archive</artifactId>
+          <version>1.2.0</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.bonitasoft.engine</groupId>
+          <artifactId>bonita-common-artifacts-model</artifactId>
+          <version>1.2.0</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.bonitasoft.engine</groupId>
+          <artifactId>bonita-form-mapping-model</artifactId>
+          <version>1.2.0</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.bonitasoft.engine</groupId>
+          <artifactId>bonita-process-definition-model</artifactId>
+          <version>1.2.0</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.hk2</groupId>
+          <artifactId>osgi-resource-locator</artifactId>
+          <version>2.4.0</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
+      <repositories>
+        <repository>
+          <id>maven-central</id>
+          <url>https://repo1.maven.org/maven2</url>
+        </repository>
+      </repositories>
+    </location>
+    <location includeDependencyDepth="infinite" includeDependencyScopes="compile,runtime,system" includeSource="false" missingManifest="generate" type="Maven" label="MavenJackson">
+      <feature id="com.fasterxml.jackson.feature" label="Jackson Feature" provider-name="Bonitasoft S.A" version="2.18.3">
+      </feature>
+      <dependencies>
+        <dependency>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
+          <artifactId>jackson-dataformat-yaml</artifactId>
+          <version>2.18.3</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
+    </location>
+    <location includeDependencyDepth="infinite" includeDependencyScopes="compile,runtime,system" includeSource="false" missingManifest="generate" type="Maven" label="MavenDependenciesWithInfiniteDepth">
+      <dependencies>
+        <dependency>
+          <groupId>org.assertj</groupId>
+          <artifactId>assertj-core</artifactId>
+          <version>3.24.2</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-core</artifactId>
+          <version>4.6.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-junit-jupiter</artifactId>
+          <version>4.6.1</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
+    </location>
+  </locations>
+  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </target>

--- a/releng/target-platform/target-platform.target
+++ b/releng/target-platform/target-platform.target
@@ -4,16 +4,18 @@
         <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
         <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <repository location="https://download.eclipse.org/releases/2022-06"/>
+            <repository location="https://download.eclipse.org/releases/2024-09"/>
             <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.emf.edapt.runtime.feature.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.gmf.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <!-- workaround as https://groovy.jfrog.io/artifactory/plugins-release/e4.24 generates very long path with Google API which make the build fail -->
-            <repository location="https://update-site.bonitasoft.com/p2/4.24/"/>
+            <repository location="http://download.eclipse.org/edapt/releases/15x/150"/>
+            <unit id="org.eclipse.emf.edapt.runtime.feature.feature.group" version="0.0.0"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://groovy.jfrog.io/artifactory/plugins-release/e4.33/"/>
             <unit id="org.codehaus.groovy30.feature.feature.group" version="0.0.0"/>
         </location>
 	        <location includeDependencyDepth="infinite" includeDependencyScopes="compile,runtime,system" includeSource="true" missingManifest="generate" type="Maven">
@@ -40,7 +42,7 @@
 	        </location>
 	        <location includeDependencyDepth="infinite" includeDependencyScopes="compile,runtime,system" includeSource="true" missingManifest="generate" type="Maven">
 
-		        <feature id="com.fasterxml.jackson.feature" label="Jackson Feature" provider-name="Bonitasoft S.A" version="2.15.2.qualifier">
+		        <feature id="com.fasterxml.jackson.feature" label="Jackson Feature" provider-name="Bonitasoft S.A" version="2.18.3">
 			        <description url="https://github.com/bonitasoft/bonita-process-model">
       Jackson Feature
    </description>
@@ -67,7 +69,7 @@
 			        <dependency>
 				        <groupId>com.fasterxml.jackson.dataformat</groupId>
 				        <artifactId>jackson-dataformat-yaml</artifactId>
-				        <version>2.15.2</version>
+				        <version>2.18.3</version>
 				        <type>jar</type>
 			        </dependency>
 		        </dependencies>
@@ -124,25 +126,25 @@
 			        <dependency>
 				        <groupId>org.bonitasoft.engine</groupId>
 				        <artifactId>bonita-business-archive</artifactId>
-				        <version>1.1.3-SNAPSHOT</version>
+				        <version>1.2.0</version>
 				        <type>jar</type>
 			        </dependency>
 			        <dependency>
 				        <groupId>org.bonitasoft.engine</groupId>
 				        <artifactId>bonita-common-artifacts-model</artifactId>
-				        <version>1.1.3-SNAPSHOT</version>
+				        <version>1.2.0</version>
 				        <type>jar</type>
 			        </dependency>
 			        <dependency>
 				        <groupId>org.bonitasoft.engine</groupId>
 				        <artifactId>bonita-form-mapping-model</artifactId>
-				        <version>1.1.3-SNAPSHOT</version>
+				        <version>1.2.0</version>
 				        <type>jar</type>
 			        </dependency>
 			        <dependency>
 				        <groupId>org.bonitasoft.engine</groupId>
 				        <artifactId>bonita-process-definition-model</artifactId>
-				        <version>1.1.3-SNAPSHOT</version>
+				        <version>1.2.0</version>
 				        <type>jar</type>
 			        </dependency>
 			        <dependency>

--- a/releng/target-platform/target-platform.tpd
+++ b/releng/target-platform/target-platform.tpd
@@ -1,0 +1,96 @@
+target "platform"
+environment JavaSE-17
+with source requirements configurePhase
+location E2024-09 "https://download.eclipse.org/releases/2024-09" {
+    org.eclipse.equinox.sdk.feature.group
+    org.eclipse.sdk.feature.group
+    org.eclipse.gmf.feature.group
+    org.eclipse.m2e.feature.feature.group
+}
+location "http://download.eclipse.org/edapt/releases/15x/150" {
+    org.eclipse.emf.edapt.runtime.feature.feature.group
+}
+location "https://groovy.jfrog.io/artifactory/plugins-release/e4.33/" {
+    org.codehaus.groovy30.feature.feature.group
+}
+maven MavenDependenciesWithInfiniteDepth scope=compile,runtime,system dependencyDepth=infinite missingManifest=generate {
+    dependency {
+        groupId="org.assertj"
+        artifactId="assertj-core"
+        version="3.24.2"
+    }
+    dependency {
+        groupId="org.mockito"
+        artifactId="mockito-core"
+        version="4.6.1"
+    }
+    dependency {
+        groupId="org.mockito"
+        artifactId="mockito-junit-jupiter"
+        version="4.6.1"
+    }
+}
+maven MavenJackson scope=compile,runtime,system dependencyDepth=infinite missingManifest=generate {
+    feature {
+        id="com.fasterxml.jackson.feature"
+        name="Jackson Feature"
+        version="2.18.3"
+        vendor="Bonitasoft S.A"
+    }
+    dependency {
+        groupId="com.fasterxml.jackson.dataformat"
+        artifactId="jackson-dataformat-yaml"
+        version="2.18.3"
+    }
+}
+maven BonitaArtifactsModels scope=compile,runtime,system dependencyDepth=none missingManifest=generate includeSources {
+    feature {
+        id="org.bonitasoft.artifacts.model.feature"
+        name="Bonita Artifacts Models Feature"
+        version="1.2.0"
+        vendor="Bonitasoft S.A"
+    }
+    dependency {
+        groupId="com.sun.activation"
+        artifactId="jakarta.activation"
+        version="1.2.2"
+    }
+    dependency {
+        groupId="com.sun.xml.bind"
+        artifactId="jaxb-osgi"
+        version="2.3.8"
+    }
+    dependency {
+        groupId="jakarta.xml.bind"
+        artifactId="jakarta.xml.bind-api"
+        version="2.3.3"
+    }
+    dependency {
+        groupId="org.bonitasoft.engine"
+        artifactId="bonita-business-archive"
+        version="1.2.0"
+    }
+    dependency {
+        groupId="org.bonitasoft.engine"
+        artifactId="bonita-common-artifacts-model"
+        version="1.2.0"
+    }
+    dependency {
+        groupId="org.bonitasoft.engine"
+        artifactId="bonita-form-mapping-model"
+        version="1.2.0"
+    }
+    dependency {
+        groupId="org.bonitasoft.engine"
+        artifactId="bonita-process-definition-model"
+        version="1.2.0"
+    }
+    dependency {
+        groupId="org.glassfish.hk2"
+        artifactId="osgi-resource-locator"
+        version="2.4.0"
+    }
+    // add ossrh-snapshots when temporary using a snapshot maven version.
+    //repository id="ossrh-snapshots" url="https://oss.sonatype.org/content/repositories/snapshots"
+    repository id="maven-central" url="https://repo1.maven.org/maven2"
+}

--- a/tests/org.bonitasoft.bonita2bar.tests/resources/my-project/extensions/resourceNameRestAPI/pom.xml
+++ b/tests/org.bonitasoft.bonita2bar.tests/resources/my-project/extensions/resourceNameRestAPI/pom.xml
@@ -11,10 +11,10 @@
   <name>ResourceName REST API</name>
   <description>REST API to manage resourceName</description>
   <properties>
+    <junit-jupiter-engine.version>5.12.0</junit-jupiter-engine.version>
     <assertj-core.version>3.24.2</assertj-core.version>
-    <junit-jupiter-engine.version>5.10.1</junit-jupiter-engine.version>
+    <mockito-core.version>5.16.0</mockito-core.version>
     <logback-classic.version>1.2.13</logback-classic.version>
-    <mockito-core.version>5.8.0</mockito-core.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/tests/org.bonitasoft.bonita2bpmn.tests/META-INF/MANIFEST.MF
+++ b/tests/org.bonitasoft.bonita2bpmn.tests/META-INF/MANIFEST.MF
@@ -12,9 +12,9 @@ Require-Bundle: assertj-core,
  org.objenesis,
  org.bonitasoft.bpm.model,
  org.bonitasoft.bpm.model.tests-utils,
- org.junit.jupiter.params,
  junit-jupiter-api,
  org.mockito.mockito-core,
  org.mockito.junit-jupiter,
  org.bonitasoft.bpm.migration,
- org.junit.platform.commons
+ junit-jupiter-params,
+ junit-platform-commons

--- a/tests/standalone-tests/src/test/resources/my-project/extensions/resourceNameRestAPI/pom.xml
+++ b/tests/standalone-tests/src/test/resources/my-project/extensions/resourceNameRestAPI/pom.xml
@@ -11,10 +11,10 @@
   <name>ResourceName REST API</name>
   <description>REST API to manage resourceName</description>
   <properties>
+    <junit-jupiter-engine.version>5.12.0</junit-jupiter-engine.version>
     <assertj-core.version>3.24.2</assertj-core.version>
-    <junit-jupiter-engine.version>5.10.1</junit-jupiter-engine.version>
+    <mockito-core.version>5.16.0</mockito-core.version>
     <logback-classic.version>1.2.13</logback-classic.version>
-    <mockito-core.version>5.8.0</mockito-core.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Update target platform and plugins in pom to Eclipse 2024.09.
(later version would require Java 21 for m2e or sdk)

Relates to [BPM-415](https://bonitasoft.atlassian.net/browse/BPM-415)

[BPM-415]: https://bonitasoft.atlassian.net/browse/BPM-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ