### PR TITLE
fix(bar): Fix "Local" environment name while building bar

### DIFF
--- a/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/BarBuilder.java
+++ b/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/BarBuilder.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 
 public class BarBuilder {
 
-    private static final String LOCAL_ENVIRONMENT = "local";
+    public static final String LOCAL_ENVIRONMENT = "Local";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BarBuilder.class);
 

--- a/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProvider.java
+++ b/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProvider.java
@@ -24,6 +24,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.bonitasoft.bonita2bar.BarArtifactProvider;
+import org.bonitasoft.bonita2bar.BarBuilder;
 import org.bonitasoft.bonita2bar.BuildBarException;
 import org.bonitasoft.bonita2bar.MavenExecutor;
 import org.bonitasoft.bonita2bar.process.pomgen.ProcessPom;
@@ -62,7 +63,8 @@ public class DependenciesArtifactProvider implements BarArtifactProvider {
             var pom = pomAccess.readPom();
             File processPomFolder = pom.getPomFile().getParentFile();
             var dependenciesFolder = new File(processPomFolder, "dependencies");
-            var profileToUse = String.format(ENV_PROFILE_FORMAT, configuration.getName());
+            String envName = configuration.getName() == null ? BarBuilder.LOCAL_ENVIRONMENT : configuration.getName();
+            var profileToUse = String.format(ENV_PROFILE_FORMAT, envName);
 
             Supplier<String> errMsg = () -> String.format("Failed to build dependencies for process %s-%s",
                     process.getName(), process.getVersion());

--- a/releng/target-platform/README.adoc
+++ b/releng/target-platform/README.adoc
@@ -20,17 +20,46 @@ You can activate and switch the target platform in the Eclipse Preferences. Sele
 
 == Updating the target platform
 
-The Tycho build uses the `platform.target` file. However, in addition, we use a `remote_platform.target` that keeps the reference to the actual p2 update sites. In order to ensure reliability of our builds, we mirror the required content of those update sites and publish it to `https://update-site.bonitasoft.com/p2/<eclipse_version>/`.
+We use these target platform related files:
 
-During the development phase, you can update the `remote_platform.target` and the `target-platform.target` to be in sync and pointing to the actual p2 update sites. The mirror is build and published before the RC version.
+* `target-platform.tpd` file is the one you should manipulate from your IDE. +
+You may use it to define your target platform constraints and use the contextual menus:
+    ** Validate
+    ** Create Target Definition file
+    ** Set as Target Platform
+* `target-platform.target` file contains the actual resolved versions and is pointing to the actual p2 update sites. +
+You will be using it typically during development phases.
 
-When possible, do not explicitly set the plugins/features version. It eases the update process. Often eclipse update sites are already versioned (eg: __https://download.eclipse.org/releases/2022-06__, __https://download.eclipse.org/technology/swtbot/releases/4.0.0/__...).
+In the `remote_platform.tpd` file, do not explicitly set the plugins/features version unless there is a strict compatiblity requirement. It eases the update process. Often eclipse update sites are already versioned (eg: __https://download.eclipse.org/releases/2022-06__, __https://download.eclipse.org/technology/swtbot/releases/4.0.0/__...).
+
+[WARNING]
+====
+Once you have regenerated the `target-platform.target` file, you need to add this instructions block in the `BonitaArtifactsModels` location to tell Tycho how to generate feature plugins:
+
+[source, xml]
+----
+      <instructions><![CDATA[
+Bundle-Name:           ${mvnGroupId}:${mvnArtifactId}:${mvnVersion}
+version:               ${version_cleanup;${mvnVersion}}
+Bundle-SymbolicName:   ${mvnGroupId}.${mvnArtifactId}
+Bundle-Version:        ${version}
+Import-Package:        *;resolution:=optional
+Export-Package:        *;version="${version}";-noimport:=true
+DynamicImport-Package: *
+]]></instructions>
+----
+
+====
 
 == Validating the target platform
 
-You may use the `target-platform-validation-plugin` to validate the target platform:
+The .tpd editor offers validation on the contextual menu.
+
+You may use the `target-platform-validation-plugin` to validate the final target platform:
 
 [source, shell]
 ----
 ./mvnw -f releng/target-platform/pom.xml validate -Pvalidate
 ----
+
+Although this shouldn't be necessary if you validated first in the .tpd editor.

--- a/releng/target-platform/target-platform.target
+++ b/releng/target-platform/target-platform.target
@@ -77,6 +77,15 @@
           <url>https://repo1.maven.org/maven2</url>
         </repository>
       </repositories>
+      <instructions><![CDATA[
+Bundle-Name:           ${mvnGroupId}:${mvnArtifactId}:${mvnVersion}
+version:               ${version_cleanup;${mvnVersion}}
+Bundle-SymbolicName:   ${mvnGroupId}.${mvnArtifactId}
+Bundle-Version:        ${version}
+Import-Package:        *;resolution:=optional
+Export-Package:        *;version="${version}";-noimport:=true
+DynamicImport-Package: *
+]]></instructions>
     </location>
     <location includeDependencyDepth="infinite" includeDependencyScopes="compile,runtime,system" includeSource="false" missingManifest="generate" type="Maven" label="MavenJackson">
       <feature id="com.fasterxml.jackson.feature" label="Jackson Feature" provider-name="Bonitasoft S.A" version="2.18.3">


### PR DESCRIPTION
When building bar, a profile with the environment is selected. For "Local" environment, the configuration name is null, but "env-Local" should be selected nevertheless (instead of "env-null").

Also fix the plugins name in the built feature.

Relates to [BPM-406](https://bonitasoft.atlassian.net/browse/BPM-406)

[BPM-406]: https://bonitasoft.atlassian.net/browse/BPM-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ