### PR TITLE
fix(bar): Limit dependencies in Bar building and fix exportedVersion in the bpmn file

### DIFF
--- a/bundles/org.bonitasoft.bonita2bar/.classpath
+++ b/bundles/org.bonitasoft.bonita2bar/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="resources"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>

--- a/bundles/org.bonitasoft.bonita2bar/pom.xml
+++ b/bundles/org.bonitasoft.bonita2bar/pom.xml
@@ -75,6 +75,14 @@
     </resources>
     <plugins>
       <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Do not overwrite the filtered resources -->
+          <copyResources>false</copyResources>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
       </plugin>

--- a/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProvider.java
+++ b/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProvider.java
@@ -69,7 +69,9 @@ public class DependenciesArtifactProvider implements BarArtifactProvider {
             Supplier<String> errMsg = () -> String.format("Failed to build dependencies for process %s-%s",
                     process.getName(), process.getVersion());
             mavenExecutor.execute(pom.getPomFile(), List.of("dependency:copy-dependencies"),
-                    Map.of("outputDirectory", "./" + dependenciesFolder.getName()),
+                    Map.of("outputDirectory", "./" + dependenciesFolder.getName(),
+                            "includeScope", "runtime",
+                            "includeTypes", "jar"),
                     List.of(profileToUse), errMsg);
 
             // explore all files in the dependencies folder

--- a/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/process/pomgen/ProcessPomGenerator.java
+++ b/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/process/pomgen/ProcessPomGenerator.java
@@ -125,8 +125,19 @@ public class ProcessPomGenerator {
         });
         // remove connector dependencies from other processes
         filterUnusedConnectorDependencies(model, process);
+        // remove zip dependencies (custom extensions deployed on their own and application pages handled otherwise)
+        filterZipDependencies(model);
         pomAccess.writePom(model);
         return pomAccess;
+    }
+
+    /**
+     * Remove zip dependencies.
+     * 
+     * @param model the maven model to update
+     */
+    private void filterZipDependencies(Model model) {
+        model.getDependencies().removeIf(dep -> "zip".equalsIgnoreCase(dep.getType()));
     }
 
     /**

--- a/tests/org.bonitasoft.bonita2bar.tests/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProviderTest.java
+++ b/tests/org.bonitasoft.bonita2bar.tests/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProviderTest.java
@@ -55,7 +55,6 @@ public class DependenciesArtifactProviderTest {
     private ProcessRegistry processRegistry;
     private Configuration configuration;
     private ProcessPomGenerator pomGenerator;
-    private JarArtifactProvider jarArtifactProvider;
 
     @BeforeEach
     void before() throws Exception {
@@ -136,7 +135,7 @@ public class DependenciesArtifactProviderTest {
         assertThat(resources).allSatisfy((key, value) -> {
             assertThat(key).matches("classpath/(\\Qeclipse-collections-\\E.*)\\.jar");
             assertThat(value).isNotNull();
-            assertThat(value.length).isPositive();
+            assertThat(value).isNotEmpty();
         });
     }
 

--- a/tests/org.bonitasoft.bonita2bar.tests/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProviderTest.java
+++ b/tests/org.bonitasoft.bonita2bar.tests/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProviderTest.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (C) 2025 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2.0 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.bonitasoft.bonita2bar.classpath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.project.MavenProject;
+import org.bonitasoft.bonita2bar.ConnectorImplementationRegistry;
+import org.bonitasoft.bonita2bar.ConnectorImplementationRegistry.ArtifactInfo;
+import org.bonitasoft.bonita2bar.ConnectorImplementationRegistry.ConnectorImplementationJar;
+import org.bonitasoft.bonita2bar.ProcessRegistry;
+import org.bonitasoft.bonita2bar.internal.M2eMavenExecutor;
+import org.bonitasoft.bonita2bar.process.pomgen.ProcessPomGenerator;
+import org.bonitasoft.bpm.model.FileUtil;
+import org.bonitasoft.bpm.model.MavenUtil;
+import org.bonitasoft.bpm.model.configuration.Configuration;
+import org.bonitasoft.bpm.model.process.util.migration.MigrationPolicy;
+import org.bonitasoft.bpm.model.util.ModelLoader;
+import org.bonitasoft.engine.bpm.bar.BusinessArchiveBuilder;
+import org.bonitasoft.engine.bpm.flownode.impl.internal.FlowElementContainerDefinitionImpl;
+import org.bonitasoft.engine.bpm.process.impl.internal.DesignProcessDefinitionImpl;
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.emf.common.util.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DependenciesArtifactProviderTest {
+
+    private DependenciesArtifactProvider dependenciesArtifactProvider;
+    private BusinessArchiveBuilder businessArchiveBuilder;
+    private ProcessRegistry processRegistry;
+    private Configuration configuration;
+    private ProcessPomGenerator pomGenerator;
+    private JarArtifactProvider jarArtifactProvider;
+
+    @BeforeEach
+    void before() throws Exception {
+        Path projectRoot = Files.createTempDirectory("my-project");
+        FileUtil.copyDirectory(new File(URLDecoder.decode(
+                FileLocator.toFileURL(CustomGroovyArtifactProviderTest.class.getResource("/my-project")).getFile(),
+                "UTF-8")).getAbsolutePath(), projectRoot.toFile().getAbsolutePath());
+        // given
+        processRegistry = ProcessRegistry.of(projectRoot.resolve("app").resolve("diagrams"),
+                MigrationPolicy.NEVER_MIGRATE_POLICY);
+        dependenciesArtifactProvider = new DependenciesArtifactProvider(new M2eMavenExecutor());
+        businessArchiveBuilder = new BusinessArchiveBuilder().createNewBusinessArchive();
+
+        File confFolder = projectRoot.resolve("app").resolve("process_configurations").toFile();
+        var configurationResource = ModelLoader.create()
+                .loadModel(URI.createFileURI(new File(confFolder, "_xQhDcRxzEeiplJoiu3AUHg.conf").getAbsolutePath()));
+        configuration = (Configuration) configurationResource.getContents().get(0);
+
+        var jsonReportFile = MavenUtil.analyze(projectRoot, MavenUtil.getMvnExecutable());
+        ConnectorImplementationRegistry connectorImplementationRegistry = createImplementationRegistry(jsonReportFile);
+
+        var appPomFile = projectRoot.resolve("app").resolve("pom.xml").toFile();
+        // load maven project
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        try (var fileReader = new FileReader(appPomFile)) {
+            var model = reader.read(fileReader);
+            MavenProject appProject = new MavenProject(model);
+            appProject.setFile(appPomFile);
+            pomGenerator = ProcessPomGenerator.create(appProject, connectorImplementationRegistry);
+        }
+    }
+
+    private static ConnectorImplementationRegistry createImplementationRegistry(Path jsonReportFile)
+            throws IOException {
+        var report = MavenUtil.loadReport(jsonReportFile);
+        var implementations = new ArrayList<ConnectorImplementationJar>();
+        implementations.addAll(adapt(
+                (List<Map<String, Object>>) report.get("connectorImplementations")));
+        implementations.addAll(adapt(
+                (List<Map<String, Object>>) report.get("filterImplementations")));
+        return ConnectorImplementationRegistry.of(implementations);
+    }
+
+    private static List<ConnectorImplementationJar> adapt(List<Map<String, Object>> implementations) {
+        return implementations.stream()
+                .map(map -> {
+                    var artifact = ((Map<String, String>) map.get("artifact"));
+                    var artifactInfo = new ArtifactInfo(artifact.get("groupId"), artifact.get("artifactId"),
+                            artifact.get("version"), artifact.get("classifier"), artifact.get("file"));
+                    return ConnectorImplementationJar.of((String) map.get("implementationId"),
+                            (String) map.get("implementationVersion"),
+                            artifactInfo,
+                            (String) map.get("jarEntry"));
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    void should_export_only_runtime_jars_in_bar() throws Exception {
+
+        var pool = processRegistry.getProcess("SimpleProcessWithContract", "1.0").orElseThrow();
+
+        // when
+        pomGenerator.withGeneratedPom(pool, pomAccess -> {
+            dependenciesArtifactProvider.build(businessArchiveBuilder, pool, pomAccess, configuration);
+            return (Void) null;
+        });
+
+        // then
+        businessArchiveBuilder.setProcessDefinition(fakeProcessDef());
+        var resources = businessArchiveBuilder.done().getResources();
+        /*
+         * Zip of REST API is ignored, it must be installed independently (only jars are installed).
+         * Provided-scoped jars are ignored.
+         * In the end, there should be only a few jars left...
+         */
+        assertThat(resources).allSatisfy((key, value) -> {
+            assertThat(key).matches("classpath/(\\Qjackson-\\E.*|\\Qeclipse-collections-\\E.*)\\.jar");
+            assertThat(value).isNotNull();
+            assertThat(value.length).isPositive();
+        });
+    }
+
+    @Test
+    void should_export_dependency_jars_in_bar() throws Exception {
+
+        var pool = processRegistry.getProcess("SimpleProcessWithContract", "1.0").orElseThrow();
+
+        // when
+        pomGenerator.withGeneratedPom(pool, pomAccess -> {
+            var pomModel = pomAccess.readPom();
+            var dependency = new org.apache.maven.model.Dependency();
+            dependency.setGroupId("org.codehaus.plexus");
+            dependency.setArtifactId("plexus-testing");
+            dependency.setVersion("1.2.0");
+            dependency.setScope("runtime");
+            pomModel.addDependency(dependency);
+            dependency = new org.apache.maven.model.Dependency();
+            dependency.setGroupId("org.codehaus.plexus");
+            dependency.setArtifactId("plexus-utils");
+            dependency.setVersion("4.0.2");
+            pomModel.addDependency(dependency);
+            pomAccess.writePom(pomModel);
+            dependenciesArtifactProvider.build(businessArchiveBuilder, pool, pomAccess, configuration);
+            return (Void) null;
+        });
+
+        // then
+        businessArchiveBuilder.setProcessDefinition(fakeProcessDef());
+        var resources = businessArchiveBuilder.done().getResources();
+        /*
+         * The plexus-testing should be in classpath
+         */
+        assertThat(resources).containsKey("classpath/plexus-testing-1.2.0.jar");
+        assertThat(resources).containsKey("classpath/plexus-utils-4.0.2.jar");
+    }
+
+    private static DesignProcessDefinitionImpl fakeProcessDef() {
+        DesignProcessDefinitionImpl designProcessDefinitionImpl = new DesignProcessDefinitionImpl();
+        FlowElementContainerDefinitionImpl processContainer = new FlowElementContainerDefinitionImpl();
+        designProcessDefinitionImpl.setProcessContainer(processContainer);
+        return designProcessDefinitionImpl;
+    }
+
+}

--- a/tests/org.bonitasoft.bonita2bar.tests/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProviderTest.java
+++ b/tests/org.bonitasoft.bonita2bar.tests/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProviderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2025 BonitaSoft S.A.
+ * Copyright (C) 2025 Bonitasoft S.A.
  * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -130,10 +130,11 @@ public class DependenciesArtifactProviderTest {
         /*
          * Zip of REST API is ignored, it must be installed independently (only jars are installed).
          * Provided-scoped jars are ignored.
+         * Jackson libs, which are transitive dependencies from the custom REST API, are ignored.
          * In the end, there should be only a few jars left...
          */
         assertThat(resources).allSatisfy((key, value) -> {
-            assertThat(key).matches("classpath/(\\Qjackson-\\E.*|\\Qeclipse-collections-\\E.*)\\.jar");
+            assertThat(key).matches("classpath/(\\Qeclipse-collections-\\E.*)\\.jar");
             assertThat(value).isNotNull();
             assertThat(value.length).isPositive();
         });

--- a/tests/org.bonitasoft.bonita2bar.tests/src/org/bonitasoft/bonita2bar/resources/BPMN2ArtifactProviderTest.java
+++ b/tests/org.bonitasoft.bonita2bar.tests/src/org/bonitasoft/bonita2bar/resources/BPMN2ArtifactProviderTest.java
@@ -56,7 +56,10 @@ class BPMN2ArtifactProviderTest {
         bpmn2ArtifactProvider.build(businessArchiveBuilder, pool, null);
         // then
         businessArchiveBuilder.setProcessDefinition(fakeProcessDef());
-        assertThat(businessArchiveBuilder.done().getResource("resources/process.bpmn")).isNotNull().isNotEmpty();
+        byte[] bpmn = businessArchiveBuilder.done().getResource("resources/process.bpmn");
+        assertThat(bpmn).isNotNull().isNotEmpty();
+        // check the exporter version is a correct semantic one
+        assertThat(new String(bpmn)).containsPattern(" exporterVersion=\"\\d+\\.\\d+\\.\\d+(\\Q-SNAPSHOT\\E)?\"");
     }
 
     private static DesignProcessDefinitionImpl fakeProcessDef() {


### PR DESCRIPTION
Limit the dependencies exported from the pom to the runtime jars.
Also fix the resource filtering, which impacts the exportedVersion in
the bpmn file.

Relates to [BPM-408](https://bonitasoft.atlassian.net/browse/BPM-408)


[BPM-408]: https://bonitasoft.atlassian.net/browse/BPM-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ