### PR TITLE
chore: remove version warning during build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,11 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</com
         </plugin>
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-compiler-plugin</artifactId>
+          <version>${tycho.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-surefire-plugin</artifactId>
           <version>${tycho.version}</version>
         </plugin>


### PR DESCRIPTION
Fix tycho-compiler-plugin version and remove warning during build