### PR TITLE
fix(target-platform): reapply workaround with update-site.bonitasoft.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ buildNumber.properties
 pom.tycho
 bin/
 **/.settings/org.sonarlint.eclipse.core.prefs
+.idea/

--- a/releng/target-platform/target-platform.target
+++ b/releng/target-platform/target-platform.target
@@ -15,7 +15,7 @@
       <repository location="http://download.eclipse.org/edapt/releases/15x/150"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
-      <unit id="org.codehaus.groovy30.feature.feature.group" version="5.6.0.v202501010114-e2409"/>
+      <unit id="org.codehaus.groovy30.feature.feature.group" version="5.5.0.v202409302028-e2409"/>
       <!-- Workaround as https://groovy.jfrog.io/artifactory/plugins-release/e4.33 generates very long paths with the Google API, which makes the build fail -->
       <repository location="https://update-site.bonitasoft.com/p2/4.33/"/>
     </location>

--- a/releng/target-platform/target-platform.target
+++ b/releng/target-platform/target-platform.target
@@ -16,7 +16,8 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.codehaus.groovy30.feature.feature.group" version="5.6.0.v202501010114-e2409"/>
-      <repository location="https://groovy.jfrog.io/artifactory/plugins-release/e4.33/"/>
+      <!-- Workaround as https://groovy.jfrog.io/artifactory/plugins-release/e4.33 generates very long paths with the Google API, which makes the build fail -->
+      <repository location="https://update-site.bonitasoft.com/p2/4.33/"/>
     </location>
     <location includeDependencyDepth="none" includeDependencyScopes="compile,runtime,system" includeSource="true" missingManifest="generate" type="Maven" label="BonitaArtifactsModels">
       <feature id="org.bonitasoft.artifacts.model.feature" label="Bonita Artifacts Models Feature" provider-name="Bonitasoft S.A" version="1.2.2">

--- a/releng/target-platform/target-platform.tpd
+++ b/releng/target-platform/target-platform.tpd
@@ -10,7 +10,9 @@ location E2024-09 "https://download.eclipse.org/releases/2024-09" {
 location "http://download.eclipse.org/edapt/releases/15x/150" {
     org.eclipse.emf.edapt.runtime.feature.feature.group
 }
-location "https://groovy.jfrog.io/artifactory/plugins-release/e4.33/" {
+// Workaround as https://groovy.jfrog.io/artifactory/plugins-release/e4.33 generates
+// very long paths with the Google API, which makes the build fail
+location "https://update-site.bonitasoft.com/p2/4.33/" {
     org.codehaus.groovy30.feature.feature.group
 }
 maven MavenDependenciesWithInfiniteDepth scope=compile,runtime,system dependencyDepth=infinite missingManifest=generate {


### PR DESCRIPTION
Bonita Code Deposit build fails because the JFrog P2 repository `https://groovy.jfrog.io/artifactory/plugins-release/e4.33` generates very long paths with the Google API.

This workaround has been overridden on 9.0.x by PR #75 