### PR TITLE
ci(release): refactor release workflow

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -6,6 +6,10 @@ on:
       - develop
       - release/*
       - support/*
+    paths-ignore:
+      - '**/README.md'
+      - '.github/**'
+      - '!.github/workflows/build-pr.yml'
 
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
       - develop
       - release/*
       - support/*
+    paths-ignore:
+      - '**/README.md'
+      - '.github/**'
+      - '!.github/workflows/build.yml'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,8 +17,6 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "develop" ]
-  schedule:
-    - cron: '33 20 * * 5'
 
 jobs:
   analyze:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,26 @@
 name: Release
 
+run-name: Release ${{ github.event.inputs.version || '' }}
+
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: Version to release (leave empty to use pom version)
+        description: 'Version to release (leave empty to use pom version)'
         type: string
         default: ''
-        required: false
-      nextVersion:
-        description: 'Next development version (leave empty to use default version incrementation policy)'
+      nextDevelopmentVersion:
+        description: 'Next development version (leave empty to use versionDigitToIncrement policy)'
         type: string
-        required: false
         default: ''
-      skipMergeReleaseInMaster:
-        description: 'Whether release branch merge should be skip into master (major/minor version only should be merged)'
-        type: boolean
-        required: false
-        default: false
+      versionDigitToIncrement:
+        description: 'Version digit to increment in the next development version: 0=major (X.0.0), 1=minor (X.Y.0), 2=patch (X.Y.Z)'
+        type: choice
+        default: '2'
+        options:
+          - '0'
+          - '1'
+          - '2'
 
 jobs:
   build:
@@ -27,18 +30,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: '0'
-        
+          fetch-depth: 0
+
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: 17
-       
+          cache: maven
+
       - name: Configure Git user
         run: |
           git config user.email "actions@github.com"
           git config user.name "GitHub Actions"
-      
-      - name: Create Release 
-        run: ./mvnw -ntp --batch-mode -Dstyle.color=always gitflow:release -DgitFlowConfig.developmentBranch=${{ github.ref_name }} -DdevelopmentVersion=${{ github.event.inputs.nextVersion }} -DreleaseVersion=${{ github.event.inputs.version }} -DskipReleaseMergeProdBranch=${{ github.event.inputs.skipMergeReleaseInMaster }} -Dverbose
+
+      - name: Create Release
+        run: >
+          ./mvnw -ntp --batch-mode gitflow:release
+          -DgitFlowConfig.developmentBranch=${{ github.ref_name }}
+          -DreleaseVersion=${{ github.event.inputs.version }}
+          -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}
+          -DversionDigitToIncrement=${{ github.event.inputs.versionDigitToIncrement }}

--- a/README.md
+++ b/README.md
@@ -1,53 +1,49 @@
 # bonita-process-model
+
 Contains the Bonita Process Domain Logic used by Studio and related tools.
 
-## License
-Copyright (C) 2022 BonitaSoft S.A.
-BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 2.0 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
-
 ## Prerequisites
-For building the code in this repository : Java [JDK 17+]
 
-For using the libraries released : Java [JDK 11+]
+For building the code in this repository: **Java JDK 17+**
+
+For using the libraries released: **Java JDK 11+**
 
 ## How to build
 
 ### With Eclipse
-Different launch configurations exists in this repository. Build Bonita Process Model.launch can be used to compile and build the model java classes. 
 
-In your Eclipse IDE, right click on the launch file, Run as => Build Bonita Process Model. 
+Different launch configurations exist in this repository. `Build Bonita Process Model.launch` can be used to compile and
+build the model java classes.
 
-A console should appear and after a while, the build will be done. You can found the jar in the target folder of each bundle project. 
+In your Eclipse IDE, right-click on the launch file, `Run as -> Build Bonita Process Model`
 
-### With Maven
+A console should appear and after a while, the build will be done. You can find the jar in the target folder of each
+bundle project.
+
+### With Maven Wrapper
+
 ```
-mvn install
+./mvnw install
 ```
-This will install all the Bonita Process Domain Logic artifacts and also a maven archetype process-reader-archetype.
 
-## How to use the Bonita Process Domain model into your own work ?
-To make it more easy for you, this project contains a maven archetype, which allows to setup a project reading a Bonita Business Process Model file.  
+This will install all the Bonita Process Domain Logic artifacts and also a maven archetype `process-reader-archetype`.
+
+## How to use the Bonita Process Domain model in your own work
+
+To make it easier for you, this project contains a maven archetype, which allows you to set up a project for reading a
+Bonita Business Process Model file.
 
 ### The maven archetype : process-reader-archetype
-This setups a classic maven project that uses:
-* [org.bonitasoft.bpm.model] (https://github.com/bonitasoft/bonita-process-model) for knowing the Bonita Process Domain Logic
-* [org.eclipse.emf.ecore](https://www.eclipse.org/emf) to manipulate and load the model
-* A sample .proc Business Process Model file
+
+This sets up a classic maven project that uses:
+
+* [org.bonitasoft.bpm.model](https://github.com/bonitasoft/bonita-process-model) for knowing the Bonita Process Domain
+  Logic
+* [org.eclipse.emf.ecore](https://eclipse.dev/emf/) to manipulate and load the model
+* A sample `.proc` Business Process Model file
 
 #### How to use the archetype
+
 ```
 mvn archetype:generate \
     -DarchetypeGroupId=org.bonitasoft.archetypes \
@@ -61,55 +57,139 @@ mvn archetype:generate \
 
 #### Archetype parameters
 
-| Parameter                      | Required   | Default value                      | Description                  |
-| -------------------------------|------------|------------------------------------|------------------------------|
-| -DarchetypeGroupId             | __true__   | __org.bonitasoft.archetypes__      | Group id of the archetype    |
-| -DarchetypeArtifactId          | __true__   | __process-reader-archetype__       | Artifact id of the archetype (must be fixed to the given value) |
-| -DarchetypeVersion             | __false__  | Latest release version (8.0.0)     | Version id of the archetype  |
-| -DgroupId                      | __true__   |                                    | Group id of the project      |
-| -DartifactId                   | __true__   |                                    | Artifact id of the project   |
-| -Dversion                      | __true__   | suggested and asked interactively  | Version of the project, suggested to use 0.0.1-SNAPSHOT |
-| -Dpackage                      | __false__  | suggested and asked interactively  | Name of the root java package|
-| -DdisplayName                  | __false__  | suggested and asked interactively  | Name of the project displayed|
-| -Ddescription                  | __false__  |     Describe your project here     | Description of the project   |
-| -Dwrapper                      | __false__  | true                               | If set to true, project will setup a [maven wrapper](https://github.com/takari/maven-wrapper)|
-| -Djava-version                 | __false__  | Same as in the main module __\*__  | Version of Java used by the project. |
-| -Dbonita-process-model-version | __false__  | Same as in the main module __\*__  | Version of the bonita-process-model used. |
-| -Dmaven-clean-version          | __false__  | Same as in the main module __\*__  | Version of maven-clean-plugin module used by the project. |
-| -Dmaven-resources-version      | __false__  | Same as in the main module __\*__  | Version of maven-resources-plugin module used by the project. |
-| -Dmaven-compiler-version       | __false__  | Same as in the main module __\*__  | Version of maven-compiler-plugin module used by the project. |
-| -Dmaven-surefire-version       | __false__  | Same as in the main module __\*__  | Version of maven-surefire-plugin module used by the project. |
-| -Dmaven-jar-version            | __false__  | Same as in the main module __\*__  | Version of maven-jar-plugin module used by the project. |
-| -Dmaven-install-version        | __false__  | Same as in the main module __\*__  | Version of maven-install-plugin module used by the project. |
-| -Dmaven-deploy-version          | __false__  | Same as in the main module __\*__  | Version of maven-deploy-plugin module used by the project. |
+| Parameter                      | Required  | Default value                     | Description                                                                                   |
+|--------------------------------|-----------|-----------------------------------|-----------------------------------------------------------------------------------------------|
+| -DarchetypeGroupId             | __true__  | __org.bonitasoft.archetypes__     | Group id of the archetype                                                                     |
+| -DarchetypeArtifactId          | __true__  | __process-reader-archetype__      | Artifact id of the archetype (must be fixed to the given value)                               |
+| -DarchetypeVersion             | __false__ | Latest release version (8.0.0)    | Version id of the archetype                                                                   |
+| -DgroupId                      | __true__  |                                   | Group id of the project                                                                       |
+| -DartifactId                   | __true__  |                                   | Artifact id of the project                                                                    |
+| -Dversion                      | __true__  | suggested and asked interactively | Version of the project, suggested to use 0.0.1-SNAPSHOT                                       |
+| -Dpackage                      | __false__ | suggested and asked interactively | Name of the root java package                                                                 |
+| -DdisplayName                  | __false__ | suggested and asked interactively | Name of the project displayed                                                                 |
+| -Ddescription                  | __false__ | Describe your project here        | Description of the project                                                                    |
+| -Dwrapper                      | __false__ | true                              | If set to true, project will setup a [maven wrapper](https://github.com/takari/maven-wrapper) |
+| -Djava-version                 | __false__ | Same as in the main module __\*__ | Version of Java used by the project.                                                          |
+| -Dbonita-process-model-version | __false__ | Same as in the main module __\*__ | Version of the bonita-process-model used.                                                     |
+| -Dmaven-clean-version          | __false__ | Same as in the main module __\*__ | Version of maven-clean-plugin module used by the project.                                     |
+| -Dmaven-resources-version      | __false__ | Same as in the main module __\*__ | Version of maven-resources-plugin module used by the project.                                 |
+| -Dmaven-compiler-version       | __false__ | Same as in the main module __\*__ | Version of maven-compiler-plugin module used by the project.                                  |
+| -Dmaven-surefire-version       | __false__ | Same as in the main module __\*__ | Version of maven-surefire-plugin module used by the project.                                  |
+| -Dmaven-jar-version            | __false__ | Same as in the main module __\*__ | Version of maven-jar-plugin module used by the project.                                       |
+| -Dmaven-install-version        | __false__ | Same as in the main module __\*__ | Version of maven-install-plugin module used by the project.                                   |
+| -Dmaven-deploy-version         | __false__ | Same as in the main module __\*__ | Version of maven-deploy-plugin module used by the project.                                    |
 
-__\* *These parameters are used to fix some versions. It is recommended not to use them and let the default values be used to ensure compatibility.*__
+__\* *These parameters are used to fix some versions. It is recommended not to use them and let the default values be
+used to ensure compatibility.*__
 
-The versions of dependent modules are taken recursively by org.bonitasoft.bpm modules, so you can not choose them. This concerns EMF Core, EMF Common, EMF Ecore XMI, EMF Edit and maven-artifact modules.
+The versions of dependent modules are taken recursively by org.bonitasoft.bpm modules, so you can not choose them. This
+concerns EMF Core, EMF Common, EMF Ecore XMI, EMF Edit and maven-artifact modules.
 
 ## Tutorial : displaying the content of a simple process
-This tutorial will help you to read the content of a process file from the Bonita Studio and to display the content (tasks, events, transitions... ). 
+
+This tutorial will help you to read the content of a process file from the Bonita Studio and to display the content (
+tasks, events, transitions... ).
 The code itself is already present in your newly project created.
 
-### The business process model file 
-In the resources folder of your newly created project, you should have a MyDiagram-1.0.proc file. 
-This file is a Business Process Model File coming from Bonita Studio. It's a very simple process containing 4 tasks and a simple flow.
+### The business process model file
+
+In the resources folder of your newly created project, you should have a MyDiagram-1.0.proc file.
+This file is a Business Process Model File coming from Bonita Studio. It's a very simple process containing 4 tasks and
+a simple flow.
 
 ### Launching the application with App.java
-The App.java contain a main method which can be used to launch this application like a java application. It does the following things:
-* **Loading the process file:** It will load the process file by using the ModelLoader class present in org.bonitasoft.bpm.model. This loading is very important : it will allow you to manipulate the content of the process itself through emf. 
-* **Displaying the content loaded in html:** The ModelDisplayer present in the project created can show you how to display in an html page the content of the process file. It can be used as a way to better understand how emf and the model logic work. 
+
+The App.java contain a main method which can be used to launch this application like a java application. It does the
+following things:
+
+* **Loading the process file:** It will load the process file by using the ModelLoader class present in
+  org.bonitasoft.bpm.model. This loading is very important : it will allow you to manipulate the content of the process
+  itself through emf.
+* **Displaying the content loaded in html:** The ModelDisplayer present in the project created can show you how to
+  display in an html page the content of the process file. It can be used as a way to better understand how emf and the
+  model logic work.
 
 ## Other tools related to Bonita Process Domain models
 
 ### Import from and export to BPMN 2.0
+
 //TODO
 
 ## P2 update site for integration with Eclipse RCP
-You can also use the maven update site as a P2 repository / update site to use the provided features in your [Eclipse RCP](https://www.vogella.com/tutorials/EclipseRCP/article.html) application.
-For the repository URL, you have to mention [mvn:org.bonitasoft.bpm:org.bonitasoft.bpm.eclipse-repository:<version>:zip] in your target platform (replace <version> with the intended one).
-P2 will then ask Maven to search for the **eclipse-repository** maven artifact and will extract the P2 repository from it (provided your Maven configuration has access to Maven Central).
+
+You can also use the maven update site as a P2 repository / update site to use the provided features in
+your [Eclipse RCP](https://www.vogella.com/tutorials/EclipseRCP/article.html) application.
+For the repository URL, you have to mention [mvn:org.bonitasoft.bpm:org.bonitasoft.bpm.eclipse-repository:<version>:zip]
+in your target platform (replace <version> with the intended one).
+P2 will then ask Maven to search for the **eclipse-repository** maven artifact and will extract the P2 repository from
+it (provided your Maven configuration has access to Maven Central).
 
 ## EMF Resources Knowledge
-- Emf official eclipse documentation: https://www.eclipse.org/modeling/emf/docs/
+
+- EMF official eclipse documentation: https://eclipse.dev/emf/docs.html
 - A tutorial describing the usage of Eclipse EMF:  https://www.vogella.com/tutorials/EclipseEMF/article.html
+
+## How to release
+
+This project uses the [gitflow-maven-plugin](https://github.com/aleksandr-m/gitflow-maven-plugin) for release
+management. Releases are created using the GitHub Actions workflow.
+
+### Branch Strategy
+
+- **develop**: Main development branch for future releases
+- **support/A.B.x**: Maintenance branches for older versions (e.g., support/8.0.x, support/8.1.x, support/9.0.x)
+- **master**: Not used (removed, use support branches for maintenance)
+
+### Creating a Release
+
+Releases are created via the GitHub Actions
+workflow [Release](https://github.com/bonitasoft/bonita-process-model/actions/workflows/release.yml)
+
+#### Workflow Parameters
+
+| Parameter                   | Description                                                                  | Default     | Example                         |
+|-----------------------------|------------------------------------------------------------------------------|-------------|---------------------------------|
+| **version**                 | Version to release (leave empty to use current pom.xml version)              | empty       | `9.0.4`                         |
+| **nextDevelopmentVersion**  | Next development version (leave empty to use versionDigitToIncrement policy) | empty       | `9.0.5-SNAPSHOT`                |
+| **versionDigitToIncrement** | Version digit to increment in next development version                       | `2` (patch) | `0`=major, `1`=minor, `2`=patch |
+
+#### Release Types
+
+**Patch Release (X.Y.Z)** - Bug fixes and minor updates
+
+- Set `versionDigitToIncrement`: **2** (default)
+- Example: `9.0.3 → 9.0.4-SNAPSHOT`
+- Use for: Support branches, hotfixes
+
+**Minor Release (X.Y.0)** - New features, backward compatible
+
+- Set `versionDigitToIncrement`: **1**
+- Example: `9.0.3 → 9.1.0-SNAPSHOT`
+- Use for: Regular releases from develop
+
+**Major Release (X.0.0)** - Breaking changes
+
+- Set `versionDigitToIncrement`: **0**
+- Example: `9.0.3 → 10.0.0-SNAPSHOT`
+- Use for: Major version bumps
+
+### Release Process
+
+When you run the workflow from any branch (develop or support/*), it will:
+
+1. Update version to release version (removes -SNAPSHOT)
+2. Commit: "chore(release): Update versions for release"
+3. Create git tag (e.g., `9.0.4`)
+4. Update version to next development version
+5. Commit: "chore(release): Update for next development version"
+6. Push commits and tags to GitHub
+
+**Note**: The workflow does NOT create a release branch - it performs the release directly on the branch you selected.
+
+### Cascade Merging for Support Branches
+
+When releasing from a **support branch**, you should manually cascade merge the changes up to newer branches and
+develop.
+
+**Example**: After doing a release from `support/8.0.x`, merge `support/8.0.x` into `support/8.1.x`, then merge
+`support/8.1.x` into `support/9.0.x`, and so on into `develop`.

--- a/pom.xml
+++ b/pom.xml
@@ -231,8 +231,12 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</com
           <artifactId>gitflow-maven-plugin</artifactId>
           <version>${gitflow-maven-plugin.version}</version>
           <configuration>
-            <!-- 0: increment major digit on develop, 1: increment minor digit on develop, 2: increment patch digit on develop -->
-            <versionDigitToIncrement>1</versionDigitToIncrement>
+            <gitFlowConfig>
+              <productionBranch>develop</productionBranch>
+              <developmentBranch>develop</developmentBranch>
+              <supportBranchPrefix>support/</supportBranchPrefix>
+            </gitFlowConfig>
+            <skipReleaseMergeProdBranch>true</skipReleaseMergeProdBranch>
             <commitMessagePrefix xml:space="preserve">chore(release): </commitMessagePrefix>
             <tychoBuild>true</tychoBuild>
             <tychoVersionsPluginVersion>${tycho.version}</tychoVersionsPluginVersion>


### PR DESCRIPTION
- Add versionDigitToIncrement workflow input (0=major, 1=minor, 2=patch) to allow users to control version bumping strategy per release
- Remove hardcoded versionDigitToIncrement from pom.xml to allow dynamic configuration via workflow
- Configure gitflow-maven-plugin with proper branch settings:
  * Set productionBranch and developmentBranch to 'develop'
  * Document supportBranchPrefix as 'support/'
  * Enable skipReleaseMergeProdBranch (master branch removed)
- Rename workflow input 'nextVersion' to 'nextDevelopmentVersion' for clarity
- Remove 'skipMergeReleaseInMaster' workflow input (now configured in pom.xml)
- Improve release command readability with multiline format
- Add maven cache to workflow for faster builds
- Add workflow run-name for better visibility in Actions UI