### PR TITLE
fix(release): set productionBranch to current branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Create Release
         run: >
           ./mvnw -ntp --batch-mode gitflow:release
+          -DgitFlowConfig.productionBranch=${{ github.ref_name }}
           -DgitFlowConfig.developmentBranch=${{ github.ref_name }}
           -DreleaseVersion=${{ github.event.inputs.version }}
           -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}


### PR DESCRIPTION
## Summary
- The gitflow-maven-plugin `release` goal checks out the `productionBranch` (defaulting to `develop`) to verify SNAPSHOT dependencies
- When releasing from `support/*` branches, this causes failures because `develop` has a different version line (e.g. `9.1.0-SNAPSHOT` vs `9.0.4-SNAPSHOT`) with parent POMs that aren't published
- Adds `-DgitFlowConfig.productionBranch=${{ github.ref_name }}` so the plugin stays on the correct branch

## Test plan
- [ ] Re-run the release workflow on `support/9.0.x` and verify the gitflow plugin no longer checks out `develop`
- [ ] Verify release workflow still works on `develop` (both values resolve to `develop`, matching current defaults)

Fixes https://github.com/bonitasoft/bonita-process-model/actions/runs/21821495882/job/62955682237