### PR TITLE
fix(release): remove gitFlowConfig overrides from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,11 +231,6 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</com
           <artifactId>gitflow-maven-plugin</artifactId>
           <version>${gitflow-maven-plugin.version}</version>
           <configuration>
-            <gitFlowConfig>
-              <productionBranch>develop</productionBranch>
-              <developmentBranch>develop</developmentBranch>
-              <supportBranchPrefix>support/</supportBranchPrefix>
-            </gitFlowConfig>
             <skipReleaseMergeProdBranch>true</skipReleaseMergeProdBranch>
             <commitMessagePrefix xml:space="preserve">chore(release): </commitMessagePrefix>
             <tychoBuild>true</tychoBuild>


### PR DESCRIPTION
## Summary
- The `gitflow-maven-plugin` constructor reads branch names via `System.getProperty()` (e.g. `-DgitFlowConfig.developmentBranch`)
- However, explicit `<gitFlowConfig>` values in the POM call the setters **after** construction, overwriting the system properties and making the `-D` CLI flags ineffective
- Removes the `<gitFlowConfig>` block from the POM — all values were plugin defaults (`supportBranchPrefix=support/`) or overridden by the workflow (`productionBranch`, `developmentBranch`)
- The `-DgitFlowConfig.productionBranch` and `-DgitFlowConfig.developmentBranch` flags already present in `release.yml` will now correctly take effect

## Root cause
When releasing from `support/9.0.x`, the plugin ignored `-DgitFlowConfig.developmentBranch=support/9.0.x` and used the POM value `develop`. It checked out the `develop` branch (version `9.1.0-SNAPSHOT`) whose parent POMs were not published, causing `Non-resolvable parent POM` errors.

## Test plan
- [ ] Re-run the release workflow on `support/9.0.x` and verify the plugin no longer checks out `develop`
- [ ] Verify release workflow still works on `develop`

Fixes https://github.com/bonitasoft/bonita-process-model/actions/runs/21821495882/job/62955682237