### PR TITLE
fix(release): make version input mandatory for Tycho builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,17 @@
 name: Release
 
-run-name: Release ${{ github.event.inputs.version || '' }}
+run-name: Release ${{ github.event.inputs.version }}
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (leave empty to use pom version)'
+        # Required because tychoBuild=true in gitflow-maven-plugin causes the plugin
+        # to skip POM version updates when releaseVersion is blank (it sets the default
+        # version to the current version including -SNAPSHOT, so no change is detected).
+        description: 'Version to release (e.g. 8.0.3). Required for Tycho builds.'
         type: string
-        default: ''
+        required: true
       nextDevelopmentVersion:
         description: 'Next development version (leave empty to use versionDigitToIncrement policy)'
         type: string


### PR DESCRIPTION
## Summary

- Make the `version` workflow input required in the release workflow
- Add comment explaining why: `tychoBuild=true` in gitflow-maven-plugin causes the plugin to skip POM version updates when `releaseVersion` is blank, resulting in tags pointing to commits with `-SNAPSHOT` versions (as happened with tag `9.0.4`)

## Root cause

With `tychoBuild=true`, when `releaseVersion` is blank, the plugin sets the default version to the current POM version **including** `-SNAPSHOT`. Since this matches the current version, the condition `!version.equals(currentVersion)` is `false` and `mvnSetVersions()` is skipped entirely. The tag is still created (with `-SNAPSHOT` stripped from the name only), but the POM files are never updated.

## Test plan

- [ ] Trigger the release workflow and verify the `version` input is now required
- [ ] Run a release with an explicit version and confirm POM files are updated before tagging