### PR TITLE
fix(bar): exclude all copied jars when configuration has no fragment

### DIFF
--- a/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProvider.java
+++ b/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProvider.java
@@ -121,15 +121,12 @@ public class DependenciesArtifactProvider implements BarArtifactProvider {
             return;
         }
 
-        // Collect all fragments once to avoid multiple tree traversals
+        // Collect all fragments once to avoid multiple tree traversals.
+        // An empty stream is a legitimate modern state (pool with no declared dependency):
+        // the whitelist is then empty and every copied jar is excluded from the BAR.
         var allFragments = containers.stream()
                 .flatMap(FragmentUtils::walkAllFragments)
                 .toList();
-
-        // No fragments = old configuration file, don't filter (backward compatibility)
-        if (allFragments.isEmpty()) {
-            return;
-        }
 
         // Whitelist: collect exact filenames of exported fragments
         Set<String> exportedExactNames = allFragments.stream()

--- a/tests/org.bonitasoft.bonita2bar.tests/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProviderFilterTest.java
+++ b/tests/org.bonitasoft.bonita2bar.tests/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProviderFilterTest.java
@@ -131,7 +131,10 @@ class DependenciesArtifactProviderFilterTest {
     }
 
     @Test
-    void should_not_filter_when_no_fragments_exist_for_backward_compatibility() throws IOException {
+    void should_remove_all_jars_when_containers_exist_but_no_fragments_are_declared() throws IOException {
+        // BPA-449: a modern configuration of a pool with no declared dependency
+        // has its containers created (e.g. OTHER) but no Fragment inside.
+        // The whitelist is empty, so every copied jar must be excluded from the BAR.
         createJarFile("lib1-1.0.jar");
         createJarFile("lib2-2.0.jar");
 
@@ -142,9 +145,7 @@ class DependenciesArtifactProviderFilterTest {
 
         provider.filterCopiedDependencies(dependenciesFolder, configuration);
 
-        assertThat(dependenciesFolder.listFiles())
-                .extracting(File::getName)
-                .containsExactlyInAnyOrder("lib1-1.0.jar", "lib2-2.0.jar");
+        assertThat(dependenciesFolder).isEmptyDirectory();
     }
 
     @Test


### PR DESCRIPTION
## Summary

Building a BAR from a process whose configuration declares **no dependency** was shipping every JAR resolved by Maven (all project dependencies), instead of an empty dependency list.

## Technical Changes

`DependenciesArtifactProvider.java`
- Remove the `allFragments.isEmpty()` early-return introduced for backward compatibility with legacy configuration files.
- An empty fragment list is now a legitimate modern state (pool with no declared dependency): the whitelist stays empty, so every copied JAR is excluded from the BAR.

`DependenciesArtifactProviderFilterTest.java`
- Rename `should_not_filter_when_no_fragments_exist_for_backward_compatibility` to `should_remove_all_jars_when_containers_exist_but_no_fragments_are_declared` and flip the assertion to expect an empty dependencies folder.

## Behavior

Before: BAR produced from a process with no declared dependency contained all project dependencies resolved by Maven.

After: BAR produced from a process with no declared dependency contains no JAR dependency.

closes [BPA-449](https://bonitasoft.atlassian.net/browse/BPA-449)

[BPA-449]: https://bonitasoft.atlassian.net/browse/BPA-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ