### PR TITLE
ci(release): notify bonita-project and bonita-studio-sp after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,3 +64,32 @@ jobs:
           -DreleaseVersion=${{ github.event.inputs.version }}
           -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}
           -DversionDigitToIncrement=${{ github.event.inputs.versionDigitToIncrement }}
+
+      - name: Detect pre-release
+        id: check
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if [[ "$VERSION" == *-* || "$VERSION" == *SNAPSHOT* ]]; then
+            echo "Pre-release detected ($VERSION), skipping downstream notifications"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Notify bonita-project
+        if: steps.check.outputs.skip == 'false'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.BONITA_CI_PAT }}
+          repository: bonitasoft/bonita-project
+          event-type: new-process-model-release
+          client-payload: '{"release": "${{ github.event.inputs.version }}", "release_notes_url": "${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.event.inputs.version }}"}'
+
+      - name: Notify bonita-studio-sp
+        if: steps.check.outputs.skip == 'false'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.BONITA_CI_PAT }}
+          repository: bonitasoft/bonita-studio-sp
+          event-type: new-process-model-release
+          client-payload: '{"release": "${{ github.event.inputs.version }}", "release_notes_url": "${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.event.inputs.version }}"}'


### PR DESCRIPTION
## Summary
- Adds two steps at the end of the release pipeline to dispatch a `new-process-model-release` event to `bonitasoft/bonita-project` and `bonitasoft/bonita-studio-sp`.
- Pre-releases (versions containing `-` or `SNAPSHOT`) are skipped.

## Context
Each release of `bonita-process-model` must be propagated to the consuming repositories. The consumers listen to the dispatched event via their own `update-process-model-version` workflow (see companion PRs in `bonita-project` and `bonita-studio-sp`) and open a PR on every branch that currently consumes the same `MAJOR.MINOR` line.

## Requirements
- `BONITA_CI_PAT` secret must be allowed to trigger `repository_dispatch` on both target repos.
