### PR TITLE
chore(rebranding): update bonitasoft.com domain references to ofelia.com

### DIFF
--- a/tests/org.bonitasoft.bonita2bar.tests/resources/my-project/extensions/resourceNameRestAPI/README.adoc
+++ b/tests/org.bonitasoft.bonita2bar.tests/resources/my-project/extensions/resourceNameRestAPI/README.adoc
@@ -12,7 +12,7 @@
 :imagesdir: ./doc/images
 
 :short-bonita-version: 10.3
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 17
 
 image::yourlogo.png[your logo here]

--- a/tests/org.bonitasoft.bonita2bar.tests/src/org/bonitasoft/bonita2bar/form/FormMappingBarResourceProviderTest.java
+++ b/tests/org.bonitasoft.bonita2bar.tests/src/org/bonitasoft/bonita2bar/form/FormMappingBarResourceProviderTest.java
@@ -88,7 +88,7 @@ class FormMappingBarResourceProviderTest {
         verify(builder).setFormMappings(formMappingModel);
         assertThat(formMappingModel.getFormMappings()).hasSize(2);
         assertThat(formMappingModel.getFormMappings()).extracting("target", "form", "type", "taskname").contains(
-                tuple(FormMappingTarget.URL, "http://www.bonitasoft.com", FormMappingType.PROCESS_OVERVIEW, null),
+                tuple(FormMappingTarget.URL, "http://www.ofelia.com", FormMappingType.PROCESS_OVERVIEW, null),
                 tuple(FormMappingTarget.INTERNAL, "custompage_StepForm", FormMappingType.TASK, "Step1"));
     }
 
@@ -169,7 +169,7 @@ class FormMappingBarResourceProviderTest {
     private Pool aPoolAndTaskWithAllTypeOfFormMappings() {
         return aPool().withName("Pool1").withVersion("1.0")
                 .havingOverviewFormMapping(aFormMapping().withType(org.bonitasoft.bpm.model.process.FormMappingType.URL)
-                        .withURL("http://www.bonitasoft.com"))
+                        .withURL("http://www.ofelia.com"))
                 .havingElements(
                         aTask().withName("Step1")
                                 .havingFormMapping(aFormMapping().havingTargetForm(

--- a/tests/standalone-tests/src/test/resources/my-project/extensions/resourceNameRestAPI/README.adoc
+++ b/tests/standalone-tests/src/test/resources/my-project/extensions/resourceNameRestAPI/README.adoc
@@ -12,7 +12,7 @@
 :imagesdir: ./doc/images
 
 :short-bonita-version: 10.3
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 17
 
 image::yourlogo.png[your logo here]


### PR DESCRIPTION
Replace bonitasoft.com domain URLs with ofelia.com equivalents. No logic changes. Part of the Bonitasoft -> Ofelia rebranding.