### PR TITLE
fix(bar): select excluded dependencies instead of deleting copied jars [BPA-684]

### DIFF
--- a/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProvider.java
+++ b/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProvider.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -82,11 +83,13 @@ public class DependenciesArtifactProvider implements BarArtifactProvider {
                             "includeTypes", "jar"),
                     List.of(profileToUse), errMsg);
 
-            // filter copied dependencies based on configuration exported flags,
-            // then add remaining files to the business archive
+            // select the copied dependencies to exclude based on configuration exported flags,
+            // then add the remaining files to the business archive. The excluded files are NOT
+            // deleted: deleting a freshly copied jar races with antivirus/indexer scans that
+            // transiently lock it on Windows, failing the whole BAR build
             if (dependenciesFolder.exists()) {
-                filterCopiedDependencies(dependenciesFolder, configuration);
-                exploreDependencies(builder, dependenciesFolder);
+                var excludedDependencies = selectExcludedDependencies(dependenciesFolder, configuration);
+                exploreDependencies(builder, dependenciesFolder, excludedDependencies);
             }
         } catch (IOException | XmlPullParserException e) {
             throw new BuildBarException(String.format("Failed to add dependencies in bar %s-%s.bar.", process.getName(),
@@ -96,29 +99,35 @@ public class DependenciesArtifactProvider implements BarArtifactProvider {
     }
 
     /**
-     * Filter copied dependencies by matching each JAR against the exported/excluded
-     * fragments from the configuration. For each file in the dependencies folder:
+     * Select the copied dependencies to exclude from the archive by matching each JAR against
+     * the exported/excluded fragments from the configuration. For each file in the dependencies
+     * folder:
      * <ol>
      * <li><b>Exact filename match with an exported fragment</b>: keep the JAR.</li>
-     * <li><b>Base-name excluded</b> (user set {@code exported=false}): delete the JAR.</li>
-     * <li><b>Base-name matches an exported fragment but version differs</b>: delete the JAR
+     * <li><b>Base-name excluded</b> (user set {@code exported=false}): exclude the JAR.</li>
+     * <li><b>Base-name matches an exported fragment but version differs</b>: exclude the JAR
      * and log a warning (Maven resolved a different version than referenced in the fragment).</li>
-     * <li><b>Unknown JAR</b> (no matching fragment at all): delete the JAR.</li>
+     * <li><b>Unknown JAR</b> (no matching fragment at all): exclude the JAR.</li>
      * </ol>
      * <p>
      * Explicit exclusion ({@code exported=false}) always takes priority over export flags,
      * to handle cases where the same artifact appears in multiple containers with conflicting flags.
+     * <p>
+     * The excluded files are left on disk on purpose: they live in a temporary per-process
+     * folder, and deleting a file right after it has been copied can fail on Windows when an
+     * antivirus or indexer holds a transient lock on it.
      *
      * @param dependenciesFolder the folder containing copied dependencies
      * @param configuration the configuration containing exported fragment information
+     * @return the paths of the copied dependencies to exclude from the archive
      */
-    void filterCopiedDependencies(File dependenciesFolder, Configuration configuration) throws IOException {
+    Set<Path> selectExcludedDependencies(File dependenciesFolder, Configuration configuration) {
         if (configuration == null) {
-            return;
+            return Set.of();
         }
         var containers = configuration.getProcessDependencies();
         if (containers.isEmpty()) {
-            return;
+            return Set.of();
         }
 
         // Collect all fragments once to avoid multiple tree traversals.
@@ -159,7 +168,8 @@ public class DependenciesArtifactProvider implements BarArtifactProvider {
         exportedExactNames.removeAll(excludedExactNames);
         excludedBases.forEach(exportedBaseToExact::remove);
 
-        // Filter files
+        // Select files to exclude
+        Set<Path> excluded = new HashSet<>();
         File[] files = dependenciesFolder.listFiles();
         if (files != null) {
             for (File file : files) {
@@ -173,34 +183,39 @@ public class DependenciesArtifactProvider implements BarArtifactProvider {
                     // (e.g. asm-3.3.1.jar exported=true, asm-9.8.jar exported=false)
                 } else if (excludedBases.contains(fileBase)) {
                     // Base-name excluded by user (exported=false) and no exact match exported
-                    Files.delete(file.toPath());
+                    excluded.add(file.toPath());
                 } else if (exportedBaseToExact.containsKey(fileBase)) {
                     // Non-runtime JAR: base name matches but version differs → exclude + warning
                     String expected = exportedBaseToExact.get(fileBase);
                     LOGGER.warn("Version mismatch: fragment expects '{}' but Maven resolved '{}'. "
                             + "Excluding from BAR.", expected, fileName);
-                    Files.delete(file.toPath());
+                    excluded.add(file.toPath());
                 } else {
                     // Unknown jar, not tracked by any fragment → exclude
-                    Files.delete(file.toPath());
+                    excluded.add(file.toPath());
                 }
             }
         }
+        return excluded;
     }
 
     /**
-     * Explore dependencies folder and add all files to the business archive.
-     * 
+     * Explore dependencies folder and add all files but the excluded ones to the business archive.
+     *
      * @param builder archive builder
      * @param dependenciesFolder folder containing dependencies
+     * @param excludedDependencies paths of the copied dependencies to exclude from the archive
      * @throws BuildBarException if an error occurs while building the archive
      * @throws IOException if an error occurs while reading the dependencies
      */
-    private void exploreDependencies(BusinessArchiveBuilder builder, File dependenciesFolder)
+    private void exploreDependencies(BusinessArchiveBuilder builder, File dependenciesFolder,
+            Set<Path> excludedDependencies)
             throws BuildBarException, IOException {
         try (Stream<Path> walker = Files.walk(dependenciesFolder.toPath())) {
             List<Path> files = walker
-                    .filter(Files::isRegularFile).toList();
+                    .filter(Files::isRegularFile)
+                    .filter(file -> !excludedDependencies.contains(file))
+                    .toList();
             for (var file : files) {
                 addDependencyToBuild(builder, file);
             }

--- a/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProvider.java
+++ b/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProvider.java
@@ -168,11 +168,16 @@ public class DependenciesArtifactProvider implements BarArtifactProvider {
         exportedExactNames.removeAll(excludedExactNames);
         excludedBases.forEach(exportedBaseToExact::remove);
 
-        // Select files to exclude
+        // Select files to exclude. Only regular files participate in the exclusion decision:
+        // the archive is built by walking regular files, so excluding a directory path would
+        // have no effect (dependency:copy-dependencies produces a flat, jar-only output anyway)
         Set<Path> excluded = new HashSet<>();
         File[] files = dependenciesFolder.listFiles();
         if (files != null) {
             for (File file : files) {
+                if (!file.isFile()) {
+                    continue;
+                }
                 String fileName = file.getName();
                 String fileBase = FragmentUtils.extractArtifactBase(fileName);
 

--- a/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/process/pomgen/ProcessPom.java
+++ b/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/process/pomgen/ProcessPom.java
@@ -26,11 +26,15 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Gives access to the pom.xml generated for a specific process.
  */
 public class ProcessPom implements Closeable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessPom.class);
 
     Path folderPath;
 
@@ -79,7 +83,14 @@ public class ProcessPom implements Closeable {
     public void close() throws IOException {
         // get rid of temporary folder
         if (folderPath != null && Files.exists(folderPath)) {
-            FileUtils.deleteDirectory(folderPath.toFile());
+            try {
+                FileUtils.deleteDirectory(folderPath.toFile());
+            } catch (IOException e) {
+                // Best-effort cleanup: a transient lock on a freshly written file (e.g. an
+                // antivirus scan on Windows) must not fail the build for a temporary folder
+                LOGGER.warn("Could not fully delete the temporary folder {} ({}). "
+                        + "It will be removed by the next clean build.", folderPath, e.getMessage());
+            }
         }
     }
 

--- a/tests/org.bonitasoft.bonita2bar.tests/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProviderFilterTest.java
+++ b/tests/org.bonitasoft.bonita2bar.tests/src/org/bonitasoft/bonita2bar/classpath/DependenciesArtifactProviderFilterTest.java
@@ -20,6 +20,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import org.bonitasoft.bpm.model.configuration.Configuration;
 import org.bonitasoft.bpm.model.configuration.builders.ConfigurationBuilder;
@@ -30,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Unit tests for {@link DependenciesArtifactProvider#filterCopiedDependencies(File, Configuration)}.
+ * Unit tests for {@link DependenciesArtifactProvider#selectExcludedDependencies(File, Configuration)}.
  */
 class DependenciesArtifactProviderFilterTest {
 
@@ -50,7 +53,7 @@ class DependenciesArtifactProviderFilterTest {
     // ── Whitelist filtering tests ──────────────────────────────────────────
 
     @Test
-    void should_remove_unchecked_transitive_when_parent_is_checked() throws IOException {
+    void should_exclude_unchecked_transitive_when_parent_is_checked() throws IOException {
         createJarFile("parent-1.0.jar");
         createJarFile("transitive-1.0.jar");
 
@@ -68,15 +71,13 @@ class DependenciesArtifactProviderFilterTest {
                                                 .notExported()))
                 .build();
 
-        provider.filterCopiedDependencies(dependenciesFolder, configuration);
+        var excluded = provider.selectExcludedDependencies(dependenciesFolder, configuration);
 
-        assertThat(dependenciesFolder.listFiles())
-                .extracting(File::getName)
-                .containsExactlyInAnyOrder("parent-1.0.jar");
+        assertThat(keptFileNames(excluded)).containsExactlyInAnyOrder("parent-1.0.jar");
     }
 
     @Test
-    void should_remove_unchecked_parent_but_keep_checked_transitives() throws IOException {
+    void should_exclude_unchecked_parent_but_keep_checked_transitives() throws IOException {
         createJarFile("parent-1.0.jar");
         createJarFile("transitive-a-1.0.jar");
         createJarFile("transitive-b-1.0.jar");
@@ -99,16 +100,15 @@ class DependenciesArtifactProviderFilterTest {
                                                 .exported()))
                 .build();
 
-        provider.filterCopiedDependencies(dependenciesFolder, configuration);
+        var excluded = provider.selectExcludedDependencies(dependenciesFolder, configuration);
 
-        assertThat(dependenciesFolder.listFiles())
-                .extracting(File::getName)
-                .containsExactlyInAnyOrder("transitive-a-1.0.jar", "transitive-b-1.0.jar");
+        assertThat(keptFileNames(excluded)).containsExactlyInAnyOrder("transitive-a-1.0.jar",
+                "transitive-b-1.0.jar");
     }
 
     @Test
-    void should_remove_unknown_jars_not_tracked_by_any_fragment() throws IOException {
-        // Whitelist approach: unknown jars (not in any fragment) are removed
+    void should_exclude_unknown_jars_not_tracked_by_any_fragment() throws IOException {
+        // Whitelist approach: unknown jars (not in any fragment) are excluded
         createJarFile("parent-1.0.jar");
         createJarFile("unknown-lib-2.0.jar");
 
@@ -122,16 +122,14 @@ class DependenciesArtifactProviderFilterTest {
                                                 .exported()))
                 .build();
 
-        provider.filterCopiedDependencies(dependenciesFolder, configuration);
+        var excluded = provider.selectExcludedDependencies(dependenciesFolder, configuration);
 
-        // Only exported jars remain, unknown jar is removed
-        assertThat(dependenciesFolder.listFiles())
-                .extracting(File::getName)
-                .containsExactlyInAnyOrder("parent-1.0.jar");
+        // Only exported jars remain, unknown jar is excluded
+        assertThat(keptFileNames(excluded)).containsExactlyInAnyOrder("parent-1.0.jar");
     }
 
     @Test
-    void should_remove_all_jars_when_containers_exist_but_no_fragments_are_declared() throws IOException {
+    void should_exclude_all_jars_when_containers_exist_but_no_fragments_are_declared() throws IOException {
         // BPA-449: a modern configuration of a pool with no declared dependency
         // has its containers created (e.g. OTHER) but no Fragment inside.
         // The whitelist is empty, so every copied jar must be excluded from the BAR.
@@ -143,13 +141,13 @@ class DependenciesArtifactProviderFilterTest {
                         FragmentContainerBuilder.aFragmentContainer("OTHER"))
                 .build();
 
-        provider.filterCopiedDependencies(dependenciesFolder, configuration);
+        var excluded = provider.selectExcludedDependencies(dependenciesFolder, configuration);
 
-        assertThat(dependenciesFolder).isEmptyDirectory();
+        assertThat(keptFileNames(excluded)).isEmpty();
     }
 
     @Test
-    void should_remove_all_known_jars_when_none_are_exported() throws IOException {
+    void should_exclude_all_known_jars_when_none_are_exported() throws IOException {
         createJarFile("lib1-1.0.jar");
         createJarFile("lib2-2.0.jar");
 
@@ -167,26 +165,57 @@ class DependenciesArtifactProviderFilterTest {
                                                 .notExported()))
                 .build();
 
-        provider.filterCopiedDependencies(dependenciesFolder, configuration);
+        var excluded = provider.selectExcludedDependencies(dependenciesFolder, configuration);
 
-        assertThat(dependenciesFolder).isEmptyDirectory();
+        assertThat(keptFileNames(excluded)).isEmpty();
     }
 
     @Test
     void should_not_filter_when_configuration_is_null() throws IOException {
         createJarFile("lib1-1.0.jar");
 
-        provider.filterCopiedDependencies(dependenciesFolder, null);
+        var excluded = provider.selectExcludedDependencies(dependenciesFolder, null);
 
+        assertThat(excluded).isEmpty();
+        assertThat(keptFileNames(excluded)).containsExactlyInAnyOrder("lib1-1.0.jar");
+    }
+
+    @Test
+    void should_not_delete_any_copied_file() throws IOException {
+        // The excluded files are selected, not deleted: deleting a freshly copied jar
+        // races with antivirus/indexer transient locks on Windows
+        createJarFile("kept-1.0.jar");
+        createJarFile("excluded-1.0.jar");
+        createJarFile("unknown-lib-2.0.jar");
+
+        Configuration configuration = ConfigurationBuilder.aConfiguration()
+                .havingProcessDependencies(
+                        FragmentContainerBuilder.aFragmentContainer("OTHER")
+                                .havingFragments(
+                                        FragmentBuilder.aFragment()
+                                                .withValue("kept-1.0.jar")
+                                                .withType("JAR")
+                                                .exported(),
+                                        FragmentBuilder.aFragment()
+                                                .withValue("excluded-1.0.jar")
+                                                .withType("JAR")
+                                                .notExported()))
+                .build();
+
+        var excluded = provider.selectExcludedDependencies(dependenciesFolder, configuration);
+
+        assertThat(excluded)
+                .extracting(path -> path.getFileName().toString())
+                .containsExactlyInAnyOrder("excluded-1.0.jar", "unknown-lib-2.0.jar");
         assertThat(dependenciesFolder.listFiles())
                 .extracting(File::getName)
-                .containsExactlyInAnyOrder("lib1-1.0.jar");
+                .containsExactlyInAnyOrder("kept-1.0.jar", "excluded-1.0.jar", "unknown-lib-2.0.jar");
     }
 
     // ── Version mismatch tests ─────────────────────────────────────────────
 
     @Test
-    void should_remove_unchecked_jar_even_when_maven_resolves_different_version() throws IOException {
+    void should_exclude_unchecked_jar_even_when_maven_resolves_different_version() throws IOException {
         // Fragment says bcpkix-jdk18on-1.78.1 (exported=false)
         // but Maven resolved bcpkix-jdk18on-1.83
         createJarFile("bcpkix-jdk18on-1.83.jar");
@@ -206,12 +235,10 @@ class DependenciesArtifactProviderFilterTest {
                                                 .exported()))
                 .build();
 
-        provider.filterCopiedDependencies(dependenciesFolder, configuration);
+        var excluded = provider.selectExcludedDependencies(dependenciesFolder, configuration);
 
-        // bcpkix removed despite version mismatch, exported-lib kept
-        assertThat(dependenciesFolder.listFiles())
-                .extracting(File::getName)
-                .containsExactlyInAnyOrder("exported-lib-1.0.jar");
+        // bcpkix excluded despite version mismatch, exported-lib kept
+        assertThat(keptFileNames(excluded)).containsExactlyInAnyOrder("exported-lib-1.0.jar");
     }
 
     @Test
@@ -230,10 +257,10 @@ class DependenciesArtifactProviderFilterTest {
                                                 .exported()))
                 .build();
 
-        provider.filterCopiedDependencies(dependenciesFolder, configuration);
+        var excluded = provider.selectExcludedDependencies(dependenciesFolder, configuration);
 
         // Excluded: base name matches but exact version differs
-        assertThat(dependenciesFolder).isEmptyDirectory();
+        assertThat(keptFileNames(excluded)).isEmpty();
     }
 
     @Test
@@ -251,11 +278,9 @@ class DependenciesArtifactProviderFilterTest {
                                                 .exported()))
                 .build();
 
-        provider.filterCopiedDependencies(dependenciesFolder, configuration);
+        var excluded = provider.selectExcludedDependencies(dependenciesFolder, configuration);
 
-        assertThat(dependenciesFolder.listFiles())
-                .extracting(File::getName)
-                .containsExactlyInAnyOrder("guava-33.0.jar");
+        assertThat(keptFileNames(excluded)).containsExactlyInAnyOrder("guava-33.0.jar");
     }
 
     @Test
@@ -278,13 +303,11 @@ class DependenciesArtifactProviderFilterTest {
                                                 .exported()))
                 .build();
 
-        provider.filterCopiedDependencies(dependenciesFolder, configuration);
+        var excluded = provider.selectExcludedDependencies(dependenciesFolder, configuration);
 
         // pdfbox excluded (version mismatch: 3.0.3 expected, 2.0.1 resolved)
         // mistral connector kept (exact match)
-        assertThat(dependenciesFolder.listFiles())
-                .extracting(File::getName)
-                .containsExactlyInAnyOrder("bonita-connector-ai-mistral-1.1.0.jar");
+        assertThat(keptFileNames(excluded)).containsExactlyInAnyOrder("bonita-connector-ai-mistral-1.1.0.jar");
     }
 
     @Test
@@ -330,14 +353,12 @@ class DependenciesArtifactProviderFilterTest {
                                                 .notExported()))
                 .build();
 
-        provider.filterCopiedDependencies(dependenciesFolder, configuration);
+        var excluded = provider.selectExcludedDependencies(dependenciesFolder, configuration);
 
-        // Exported fragments kept, version-mismatched unchecked jars and unknown jars removed
-        assertThat(dependenciesFolder.listFiles())
-                .extracting(File::getName)
-                .containsExactlyInAnyOrder(
-                        "bonita-connector-ai-mistral-1.1.0.jar",
-                        "FastInfoset-1.2.15.jar");
+        // Exported fragments kept, version-mismatched unchecked jars and unknown jars excluded
+        assertThat(keptFileNames(excluded)).containsExactlyInAnyOrder(
+                "bonita-connector-ai-mistral-1.1.0.jar",
+                "FastInfoset-1.2.15.jar");
     }
 
     // ── Conflicting exported flags across containers (post-flatten scenario) ──
@@ -381,13 +402,12 @@ class DependenciesArtifactProviderFilterTest {
                                                 .exported()))
                 .build();
 
-        provider.filterCopiedDependencies(dependenciesFolder, configuration);
+        var excluded = provider.selectExcludedDependencies(dependenciesFolder, configuration);
 
         // pdfbox excluded (user's exported=false in OTHER wins over exported=true in CONNECTOR child)
         // fontbox and openhtmltopdf-pdfbox kept (exported=true in OTHER)
-        assertThat(dependenciesFolder.listFiles())
-                .extracting(File::getName)
-                .containsExactlyInAnyOrder("fontbox-2.0.24.jar", "openhtmltopdf-pdfbox-1.0.10.jar");
+        assertThat(keptFileNames(excluded)).containsExactlyInAnyOrder("fontbox-2.0.24.jar",
+                "openhtmltopdf-pdfbox-1.0.10.jar");
     }
 
     @Test
@@ -411,16 +431,22 @@ class DependenciesArtifactProviderFilterTest {
                                                 .notExported()))
                 .build();
 
-        provider.filterCopiedDependencies(dependenciesFolder, configuration);
+        var excluded = provider.selectExcludedDependencies(dependenciesFolder, configuration);
 
-        // asm-3.3.1.jar kept (exact match exported), asm-9.8.jar removed (not exported)
-        assertThat(dependenciesFolder.listFiles())
-                .extracting(File::getName)
-                .containsExactlyInAnyOrder("asm-3.3.1.jar");
+        // asm-3.3.1.jar kept (exact match exported), asm-9.8.jar excluded (not exported)
+        assertThat(keptFileNames(excluded)).containsExactlyInAnyOrder("asm-3.3.1.jar");
     }
 
     private void createJarFile(String name) throws IOException {
         Files.write(dependenciesFolder.toPath().resolve(name), new byte[] { 0 });
+    }
+
+    private List<String> keptFileNames(Set<Path> excluded) {
+        return Stream.of(dependenciesFolder.listFiles())
+                .map(File::toPath)
+                .filter(path -> !excluded.contains(path))
+                .map(path -> path.getFileName().toString())
+                .toList();
     }
 
 }


### PR DESCRIPTION
## Summary

Fixes [BPA-684](https://bonitasoft.atlassian.net/browse/BPA-684): on Windows, the BAR build can fail with `Failed to add dependencies in bar ...: The process cannot access the file because it is being used by another process` when `DependenciesArtifactProvider` deletes a jar it copied milliseconds earlier - antivirus / Windows Search indexer scans transiently lock freshly written files. Reproduced twice by a user on different jars each time (guava, then rhino), the signature of a roving transient scan lock.

## Approach: select instead of delete

The exclusion decision logic (exact-name whitelist, user exclusions taking priority, version-mismatch detection with warning) is byte-for-byte unchanged - but exclusions are now applied when adding files to the archive (`exploreDependencies` skips the excluded set) instead of deleting files from disk. No deletion, no race. Excluded files stay in the temporary per-process folder, which was always deleted after the build anyway.

**Why not `excludeArtifactIds` on `dependency:copy-dependencies` (filter before copy)?** The decision semantics are keyed on exact *file names* - including two versions of the same artifact with opposite exported flags (`asm-3.3.1.jar` exported / `asm-9.8.jar` excluded, covered by an existing test) - which artifactId-based plugin excludes cannot express. It would also silently drop the version-mismatch warning, since mismatched files would never be copied.

## Second lock-sensitive point hardened

`ProcessPom.close()` deletes the whole temporary folder after the BAR build and previously failed the build on IOException - the same transient lock would just have moved there. Cleanup is now best-effort: a failure logs a warning and leaves the folder for the next clean build.

## Tests

- All 12 existing filter tests adapted to assert the selection (identical expected keep-sets per scenario), including the asm two-versions case and the post-flatten conflicting-flags case.
- New invariant test: excluded files are selected but never deleted from disk.
- `DependenciesArtifactProviderTest` (integration, asserts final BAR content) passes **unchanged**, demonstrating identical packaging output.
- Full build green locally except a pre-existing standalone-tests environment failure (`No UIDesigner form is defined`, nested run of the released bonita-project-maven-plugin 1.0.0 - unaffected by this diff; CI on support/9.0.x HEAD is green with it).

[BPA-684]: https://bonitasoft.atlassian.net/browse/BPA-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ