### PR TITLE
ci(sonar): setup java 21 as minimum requirement

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -15,9 +15,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -43,4 +40,7 @@ jobs:
           java-version: 21
 
       - name: Sonar Scanner
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # PR decoration / PR info for SonarCloud
         run: ./mvnw -B -ntp sonar:sonar

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -15,6 +15,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -31,7 +34,13 @@ jobs:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 
       - name: Build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./mvnw -B -ntp verify sonar:sonar -Pjacoco
+        run: ./mvnw -B -ntp verify -Pjacoco
+
+      - name: Setup Java 21 for Sonar Scanner
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Sonar Scanner
+        run: ./mvnw -B -ntp sonar:sonar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -48,4 +45,7 @@ jobs:
           java-version: 21
 
       - name: Sonar Scanner
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # PR decoration / PR info for SonarCloud
         run: ./mvnw -B -ntp sonar:sonar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -36,7 +39,13 @@ jobs:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 
       - name: Build and deploy
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        run: ./mvnw -B -ntp deploy sonar:sonar -Pjacoco
+        run: ./mvnw -B -ntp deploy -Pjacoco
+
+      - name: Setup Java 21 for Sonar Scanner
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Sonar Scanner
+        run: ./mvnw -B -ntp sonar:sonar

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</com
   </scm>
   <properties>
     <cyclonedx.version>2.7.9</cyclonedx.version>
-    <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
+    <sonar-maven-plugin.version>5.1.0.4751</sonar-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
     <tycho.version>4.0.7</tycho.version>
     <emf-ecore.version>2.27.0</emf-ecore.version>


### PR DESCRIPTION
SonarQube Cloud no longer supports Java 17 to run analysis. It requires minimum Java 21.

The build/deploy continues to run on Java 17 (the project keeps targeting Java 17), and a dedicated `sonar:sonar` step runs on Java 21 for the scanner.

## Changes

- Split the workflows into two phases: build/deploy on Java 17, then a separate Sonar Scanner step on Java 21 (`build.yml`, `build-pr.yml`).
- Scope `SONAR_TOKEN` and `GITHUB_TOKEN` to the Sonar Scanner step only (they are used solely by `sonar:sonar`) instead of the whole job, to limit their exposure to third-party actions.
- Upgrade `sonar-maven-plugin` from `3.9.1.2184` to `5.1.0.4751` for SonarCloud compatibility with the Java 21 scanner.

Related to [BEN-77](https://bonitasoft.atlassian.net/browse/BEN-77)

[BEN-77]: https://bonitasoft.atlassian.net/browse/BEN-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
