### PR TITLE
chore(ci): add dependabot github-actions updates for support branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,40 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
 
-  # Maintain dependencies for GitHub Actions
+  # Maintain dependencies for GitHub Actions (develop)
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: develop
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # Maintain dependencies for GitHub Actions (support/8.0.x)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: support/8.0.x
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # Maintain dependencies for GitHub Actions (support/8.1.x)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: support/8.1.x
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # Maintain dependencies for GitHub Actions (support/9.0.x)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: support/9.0.x
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
## What

Extend the Dependabot configuration so GitHub Actions updates are opened against the maintenance branches in addition to `develop`:

- `support/8.0.x`
- `support/8.1.x`
- `support/9.0.x`

## Why

GitHub Actions in the support branches' workflows were only being kept up to date on `develop`. This adds coverage for the active maintenance branches.

## Notes

- Dependabot does **not** support wildcards (e.g. `support/*`) for `target-branch`, so each branch needs its own `github-actions` entry.
- The config is read only from the default branch (`develop`), so this single file drives update PRs for all four branches.
- Maven configuration was intentionally left unchanged (`develop` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)