### PR TITLE
fix(bar): use m2e execution context to run maven request

### DIFF
--- a/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/internal/M2eMavenExecutor.java
+++ b/bundles/org.bonitasoft.bonita2bar/src/org/bonitasoft/bonita2bar/internal/M2eMavenExecutor.java
@@ -21,20 +21,15 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Supplier;
 
-import org.apache.maven.Maven;
 import org.apache.maven.execution.BuildSuccess;
 import org.apache.maven.execution.BuildSummary;
-import org.apache.maven.execution.MavenExecutionResult;
 import org.bonitasoft.bonita2bar.BuildBarException;
 import org.bonitasoft.bonita2bar.MavenExecutor;
 import org.bonitasoft.bpm.model.util.EnvironmentUtil;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.m2e.core.MavenPlugin;
-import org.eclipse.m2e.core.embedder.ICallable;
 import org.eclipse.m2e.core.embedder.IMaven;
-import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
 
 /**
  * {@link MavenExecutor} using the M2E maven plugin.
@@ -74,18 +69,16 @@ public class M2eMavenExecutor implements MavenExecutor {
             request.setUserProperties(userProperties);
             request.setActiveProfiles(activeProfiles);
             request.setPom(pomFile);
-            var executionResult = ctx.execute(new ICallable<MavenExecutionResult>() {
-
-                @Override
-                public MavenExecutionResult call(IMavenExecutionContext context, IProgressMonitor monitor)
-                        throws CoreException {
-                    return maven.lookup(Maven.class).execute(request);
-                }
-
-            }, null);
+            // Run the request through the m2e execution context so that the Maven session is fully
+            // set up (projects, workspace reader, event spies) before the build starts. Looking up and
+            // executing Maven ourselves leaves the session incompletely initialized and fails with a
+            // ReactorReader NPE on MavenSession.getProjects() with maven-core 3.9.x.
+            var executionResult = ctx.execute(request);
             BuildSummary buildSummary = executionResult.getBuildSummary(executionResult.getProject());
             if (!(buildSummary instanceof BuildSuccess)) {
-                throw new BuildBarException(errorMessageBase.get(), executionResult.getExceptions().get(0));
+                var exceptions = executionResult.getExceptions();
+                throw new BuildBarException(errorMessageBase.get(),
+                        exceptions.isEmpty() ? null : exceptions.get(0));
             }
         } catch (CoreException e) {
             throw new BuildBarException(errorMessageBase.get(), e);


### PR DESCRIPTION
## Problem

CI on `support/9.0.x` fails on a single test: `ConnectorImplementationArtifactProviderTest.should_add_connector_in_bar`.

`M2eMavenExecutor` runs `dependency:copy-dependencies` in the m2e-embedded Maven (maven-core 3.9.9) and fails with:

```
BuildBarException: Failed to build dependencies for process ProcessWithConnectors-1.0
Caused by: NullPointerException: Cannot invoke "java.util.List.stream()"
  because the return value of "org.apache.maven.execution.MavenSession.getProjects()" is null
  at org.apache.maven.ReactorReader.<init>(ReactorReader.java:80)
```

The executor ran the build by looking up and executing Maven itself from the **outer plugin container**:

```java
ctx.execute((context, monitor) -> maven.lookup(Maven.class).execute(request), null);
```

This leaves the Maven session incompletely initialized (projects/workspace reader not wired), so `ReactorReader` — which eagerly reads `session.getProjects()` in its constructor under maven-core 3.9.x — hits an NPE.

## Fix

Run the request through the supported m2e API `IMavenExecutionContext.execute(MavenExecutionRequest)`, which executes Maven through the **context-scoped component lookup** with proper `EventSpyDispatcher` setup, ensuring the session is fully set up before the build starts.

```java
var executionResult = ctx.execute(request);
```

Also guards against an empty exception list (the old `getExceptions().get(0)` would have thrown `IndexOutOfBoundsException`).

## Notes

- `execute(MavenExecutionRequest)` has existed in the m2e API since 2023-03, so it is present in the pinned m2e 2.6.2 target platform. The bundle manifest places no version constraint on `org.eclipse.m2e.core`.
- The offending code path uses the m2e-embedded Maven; it could not be locally reproduced (`eclipse-plugin` packaging requires the full Tycho target platform). Validation relies on the OSGi test running green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)