### PR TITLE
fix(tests): decrypt settings.xml server passwords in BarBuilderIT

### DIFF
--- a/tests/standalone-tests/src/test/java/org/bonitasoft/bpm/standalone/tests/BarBuilderIT.java
+++ b/tests/standalone-tests/src/test/java/org/bonitasoft/bpm/standalone/tests/BarBuilderIT.java
@@ -42,6 +42,8 @@ import org.apache.maven.project.ProjectBuildingResult;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.SettingsUtils;
+import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.apache.maven.settings.io.xpp3.SettingsXpp3Reader;
 import org.bonitasoft.bonita2bar.BarBuilderFactory;
 import org.bonitasoft.bonita2bar.BarBuilderFactory.BuildConfig;
@@ -77,6 +79,9 @@ class BarBuilderIT {
 
     @Inject
     protected org.apache.maven.project.ProjectBuilder projectBuilder;
+
+    @Inject
+    protected SettingsDecrypter settingsDecrypter;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -121,7 +126,9 @@ class BarBuilderIT {
         buildingRequest.setActiveProfileIds(settings.getActiveProfiles());
 
         DefaultAuthenticationSelector authSelector = new DefaultAuthenticationSelector();
-        settings.getServers().forEach(server -> {
+        // decrypt server passwords like the Maven CLI does
+        var decryptedSettings = settingsDecrypter.decrypt(new DefaultSettingsDecryptionRequest(settings));
+        decryptedSettings.getServers().forEach(server -> {
             AuthenticationBuilder authBuilder = new AuthenticationBuilder();
             authBuilder.addUsername(server.getUsername());
             authBuilder.addPassword(server.getPassword());


### PR DESCRIPTION
# PR Description

## Problem

All 3 `BarBuilderIT` tests fail locally with `ProjectBuildingException` when the developer's `~/.m2/settings.xml` stores server passwords Maven-encrypted (`{...}` entries backed by `~/.m2/settings-security.xml`):

```
[FATAL] Non-resolvable parent POM for com.company:my-project-parent:0.0.1:
Could not transfer artifact org.bonitasoft:bonita-project:pom:10.2.0 from/to releases
(https://bonitasoft.jfrog.io/artifactory/releases): status code: 401
```

The test parses `settings.xml` with `SettingsXpp3Reader` and passes `server.getPassword()` verbatim to aether's `AuthenticationBuilder`, so the literal encrypted blob is sent as the password and Artifactory answers 401. Since the `ProjectBuildingRequest` only contains the repositories injected from the settings profiles (no Maven Central) and a private `target/local-repo`, there is no fallback and the parent pom of the `my-project` test resource cannot be resolved.

## Fix

Run the parsed settings through `SettingsDecrypter` (injected from the Plexus container, wired by maven-core's `SecDispatcherProvider` which reads `~/.m2/settings-security.xml` like the Maven CLI) and build the authentication selector from the decrypted servers.

Plaintext passwords pass through decryption unchanged, so CI settings coming from secrets are unaffected.

## Verification

`./mvnw verify -pl tests/standalone-tests -am` with encrypted settings: `Tests run: 3, Failures: 0, Errors: 0` (previously 3 errors).
