### PR TITLE
chore(deps): bump bonita-artifacts-model to 2.0.0

### DIFF
--- a/bundles/org.bonitasoft.bonita2bar/pom.xml
+++ b/bundles/org.bonitasoft.bonita2bar/pom.xml
@@ -53,17 +53,17 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.36</version>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy</artifactId>
-      <version>3.0.19</version>
+      <version>${groovy.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>ecj</artifactId>
-      <version>3.26.0</version>
+      <version>${ecj.version}</version>
     </dependency>
   </dependencies>
   <build>
@@ -74,14 +74,6 @@
       </resource>
     </resources>
     <plugins>
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-compiler-plugin</artifactId>
-        <configuration>
-          <!-- Do not overwrite the filtered resources -->
-          <copyResources>false</copyResources>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-compiler-plugin</artifactId>

--- a/features/org.bonitasoft.bonita2bar.feature/feature.xml
+++ b/features/org.bonitasoft.bonita2bar.feature/feature.xml
@@ -33,9 +33,9 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
       <import feature="org.bonitasoft.bpm.connector.feature" version="9.0.0" match="compatible"/>
       <import feature="org.bonitasoft.bpm.model.feature" version="9.0.0" match="compatible"/>
       <import feature="org.bonitasoft.bonita2bpmn.feature" version="9.0.0" match="compatible"/>
-      <import plugin="org.codehaus.groovy" version="3.0.0"/>
+      <import feature="org.bonitasoft.artifacts.model.feature" version="2.0.0" match="compatible"/>
       <import feature="com.fasterxml.jackson.feature" version="2.15.2.qualifier"/>
-      <import feature="org.bonitasoft.artifacts.model.feature" version="1.0.0.qualifier"/>
+      <import plugin="org.codehaus.groovy" version="3.0.0"/>
    </requires>
 
    <plugin

--- a/pom.xml
+++ b/pom.xml
@@ -69,31 +69,27 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</com
     <!-- Bonitasoft dependencies versions -->
     <bonita-artifacts-model.version>2.0.0</bonita-artifacts-model.version>
     <!-- Dependency versions -->
-    <archetype-packaging.version>3.4.1</archetype-packaging.version>
-    <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
-    <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
-    <cyclonedx.version>2.9.2</cyclonedx.version>
     <ecj.version>3.26.0</ecj.version>
     <emf-common.version>2.31.0</emf-common.version>
     <emf-ecore.version>2.37.0</emf-ecore.version>
     <emf-edit.version>2.22.0</emf-edit.version>
     <emf-xmi.version>2.38.0</emf-xmi.version>
-    <maven-artifact.version>3.9.3</maven-artifact.version>
-    <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
-    <maven-invoker-plugin.version>3.3.0</maven-invoker-plugin.version>
-    <archetype-packaging.version>3.4.1</archetype-packaging.version>
-    <flatten-maven-plugin.version>1.8.0</flatten-maven-plugin.version>
-    <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
-    <spotless-maven-plugin.version>3.9.0</spotless-maven-plugin.version>
-    <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>
     <groovy.version>3.0.19</groovy.version>
     <jackson-bom.version>2.22.1</jackson-bom.version>
-    <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
     <maven-artifact.version>3.9.3</maven-artifact.version>
+    <maven-core.version>3.9.16</maven-core.version>
+    <slf4j.version>1.7.36</slf4j.version>
+    <!-- Maven plugin versions -->
+    <archetype-packaging.version>3.4.1</archetype-packaging.version>
+    <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
+    <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
+    <cyclonedx.version>2.9.2</cyclonedx.version>
+    <flatten-maven-plugin.version>1.8.0</flatten-maven-plugin.version>
+    <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
     <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
     <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-    <maven-core.version>3.9.16</maven-core.version>
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
@@ -101,7 +97,6 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</com
     <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
     <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
-    <slf4j.version>1.7.36</slf4j.version>
     <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
     <spotless-maven-plugin.version>3.9.0</spotless-maven-plugin.version>
     <tycho.version>4.0.13</tycho.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,15 +59,24 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</com
     <url>https://github.com/bonitasoft/bonita-process-model</url>
   </scm>
   <properties>
-    <cyclonedx.version>2.9.2</cyclonedx.version>
-    <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
-    <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
-    <tycho.version>4.0.13</tycho.version>
+    <!-- Java version -->
+    <java.version>17</java.version>
+    <maven.compiler.release>${java.version}</maven.compiler.release>
+    <!-- Properties encoding used by the maven compiler -->
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <!-- Skip deploy for all modules by default, and only activate it for the ones we want to deploy -->
+    <maven.deploy.skip>true</maven.deploy.skip>
+    <!-- Bonitasoft dependencies versions -->
     <bonita-artifacts-model.version>1.2.2</bonita-artifacts-model.version>
-    <emf-ecore.version>2.37.0</emf-ecore.version>
+    <!-- Dependency versions -->
+    <archetype-packaging.version>3.4.1</archetype-packaging.version>
+    <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
+    <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
+    <cyclonedx.version>2.9.2</cyclonedx.version>
     <emf-common.version>2.31.0</emf-common.version>
-    <emf-xmi.version>2.38.0</emf-xmi.version>
+    <emf-ecore.version>2.37.0</emf-ecore.version>
     <emf-edit.version>2.22.0</emf-edit.version>
+    <emf-xmi.version>2.38.0</emf-xmi.version>
     <maven-artifact.version>3.9.3</maven-artifact.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-invoker-plugin.version>3.3.0</maven-invoker-plugin.version>
@@ -76,17 +85,22 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</com
     <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <spotless-maven-plugin.version>3.9.0</spotless-maven-plugin.version>
     <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>
-    <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
-    <!-- standard maven plugins versions -->
-    <maven-core.version>3.9.16</maven-core.version>
-    <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
-    <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
-    <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-    <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
-    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
-    <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
-    <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
+    <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
+    <maven-artifact.version>3.9.3</maven-artifact.version>
     <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
+    <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
+    <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+    <maven-core.version>3.9.16</maven-core.version>
+    <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
+    <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
+    <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
+    <maven-invoker-plugin.version>3.3.0</maven-invoker-plugin.version>
+    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
+    <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
+    <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
+    <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
+    <spotless-maven-plugin.version>3.9.0</spotless-maven-plugin.version>
+    <tycho.version>4.0.13</tycho.version>
     <!-- Spotless resources location -->
     <eclipse.formatter.file>${maven.multiModuleProjectDirectory}/formatter.xml</eclipse.formatter.file>
     <eclipse.importorder.file>${maven.multiModuleProjectDirectory}/eclipse.importorder</eclipse.importorder.file>
@@ -99,10 +113,6 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</com
     <sonar.exclusions>src-gen/**/*</sonar.exclusions>
     <sonar.sources></sonar.sources>
     <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/releng/coverage-report/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>17</java.version>
-    <maven.compiler.release>${java.version}</maven.compiler.release>
-    <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</com
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
     <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <cyclonedx.version>2.9.2</cyclonedx.version>
+    <ecj.version>3.26.0</ecj.version>
     <emf-common.version>2.31.0</emf-common.version>
     <emf-ecore.version>2.37.0</emf-ecore.version>
     <emf-edit.version>2.22.0</emf-edit.version>
@@ -85,6 +86,8 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</com
     <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <spotless-maven-plugin.version>3.9.0</spotless-maven-plugin.version>
     <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>
+    <groovy.version>3.0.19</groovy.version>
+    <jackson-bom.version>2.22.1</jackson-bom.version>
     <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
     <maven-artifact.version>3.9.3</maven-artifact.version>
     <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
@@ -98,6 +101,7 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</com
     <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
     <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
     <spotless-maven-plugin.version>3.9.0</spotless-maven-plugin.version>
     <tycho.version>4.0.13</tycho.version>
@@ -119,7 +123,7 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</com
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.22.1</version>
+        <version>${jackson-bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</com
     <!-- Skip deploy for all modules by default, and only activate it for the ones we want to deploy -->
     <maven.deploy.skip>true</maven.deploy.skip>
     <!-- Bonitasoft dependencies versions -->
-    <bonita-artifacts-model.version>1.2.2</bonita-artifacts-model.version>
+    <bonita-artifacts-model.version>2.0.0</bonita-artifacts-model.version>
     <!-- Dependency versions -->
     <archetype-packaging.version>3.4.1</archetype-packaging.version>
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>

--- a/releng/target-platform/target-platform.target
+++ b/releng/target-platform/target-platform.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="platform" sequenceNumber="1744213320">
+<target name="platform" sequenceNumber="1744213321">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.equinox.sdk.feature.group" version="3.23.1400.v20240820-0604"/>
@@ -19,49 +19,49 @@
       <repository location="https://groovy.jfrog.io/artifactory/plugins-release/e4.33/"/>
     </location>
     <location includeDependencyDepth="none" includeDependencyScopes="compile,runtime,system" includeSource="true" missingManifest="generate" type="Maven" label="BonitaArtifactsModels">
-      <feature id="org.bonitasoft.artifacts.model.feature" label="Bonita Artifacts Models Feature" provider-name="Bonitasoft S.A" version="1.2.2">
+      <feature id="org.bonitasoft.artifacts.model.feature" label="Bonita Artifacts Models Feature" provider-name="Bonitasoft S.A" version="2.0.0">
       </feature>
       <dependencies>
         <dependency>
           <groupId>com.sun.activation</groupId>
           <artifactId>jakarta.activation</artifactId>
-          <version>1.2.2</version>
+          <version>2.0.1</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>com.sun.xml.bind</groupId>
           <artifactId>jaxb-osgi</artifactId>
-          <version>2.3.8</version>
+          <version>3.0.2</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>jakarta.xml.bind</groupId>
           <artifactId>jakarta.xml.bind-api</artifactId>
-          <version>2.3.3</version>
+          <version>3.0.1</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.bonitasoft.engine</groupId>
           <artifactId>bonita-business-archive</artifactId>
-          <version>1.2.2</version>
+          <version>2.0.0</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.bonitasoft.engine</groupId>
           <artifactId>bonita-common-artifacts-model</artifactId>
-          <version>1.2.2</version>
+          <version>2.0.0</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.bonitasoft.engine</groupId>
           <artifactId>bonita-form-mapping-model</artifactId>
-          <version>1.2.2</version>
+          <version>2.0.0</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.bonitasoft.engine</groupId>
           <artifactId>bonita-process-definition-model</artifactId>
-          <version>1.2.2</version>
+          <version>2.0.0</version>
           <type>jar</type>
         </dependency>
         <dependency>

--- a/releng/target-platform/target-platform.tpd
+++ b/releng/target-platform/target-platform.tpd
@@ -47,43 +47,43 @@ maven BonitaArtifactsModels scope=compile,runtime,system dependencyDepth=none mi
     feature {
         id="org.bonitasoft.artifacts.model.feature"
         name="Bonita Artifacts Models Feature"
-        version="1.2.2"
+        version="2.0.0"
         vendor="Bonitasoft S.A"
     }
     dependency {
         groupId="com.sun.activation"
         artifactId="jakarta.activation"
-        version="1.2.2"
+        version="2.0.1"
     }
     dependency {
         groupId="com.sun.xml.bind"
         artifactId="jaxb-osgi"
-        version="2.3.8"
+        version="3.0.2"
     }
     dependency {
         groupId="jakarta.xml.bind"
         artifactId="jakarta.xml.bind-api"
-        version="2.3.3"
+        version="3.0.1"
     }
     dependency {
         groupId="org.bonitasoft.engine"
         artifactId="bonita-business-archive"
-        version="1.2.2"
+        version="2.0.0"
     }
     dependency {
         groupId="org.bonitasoft.engine"
         artifactId="bonita-common-artifacts-model"
-        version="1.2.2"
+        version="2.0.0"
     }
     dependency {
         groupId="org.bonitasoft.engine"
         artifactId="bonita-form-mapping-model"
-        version="1.2.2"
+        version="2.0.0"
     }
     dependency {
         groupId="org.bonitasoft.engine"
         artifactId="bonita-process-definition-model"
-        version="1.2.2"
+        version="2.0.0"
     }
     dependency {
         groupId="org.glassfish.hk2"


### PR DESCRIPTION
# PR Description

Bump `bonita-artifacts-model` from 1.2.2 to 2.0.0, plus preparatory pom cleanups.

## Changes

- **pom cleanups**: reorder properties for clarity, extract remaining hardcoded dependency versions into properties, deduplicate the properties block (sorted, grouped into "Dependency versions" / "Maven plugin versions"), and remove a duplicate `tycho-compiler-plugin` block in the bonita2bar pom.
- **`bonita-artifacts-model.version` 1.2.2 → 2.0.0** in the root pom.
- **Target platform aligned in lockstep** (`releng/target-platform/*.tpd`/`.target`): the 4 `org.bonitasoft.engine` artifacts and the wrapping feature → 2.0.0, and the JAXB stack moved to the jakarta namespace used by 2.0.0: `jakarta.xml.bind-api` 2.3.3 → 3.0.1, `com.sun.xml.bind:jaxb-osgi` 2.3.8 → 3.0.2, `com.sun.activation:jakarta.activation` 1.2.2 → 2.0.1 (versions taken from `bonita-business-archive` 2.0.0's own pom; bundle symbolic names unchanged, so no MANIFEST changes needed).
- **`bonita2bar.feature` now requires artifacts model feature 2.0.0**: the import gets `match="compatible"` like the other bonitasoft feature imports, publishing a real `[2.0.0,3.0.0)` p2 requirement (verified in the generated site metadata) instead of the previous unconstrained `0.0.0`. A 1.x/2.x feature mismatch now fails at resolution time instead of at runtime. The version deliberately has no `.qualifier` suffix (`2.0.0` sorts below `2.0.0.qualifier`, which would exclude the exact 2.0.0 feature).

## Why the target platform must move together

bonita-artifacts-model 2.0.0 migrated from `javax.xml.bind` (JAXB 2.x) to `jakarta.xml.bind` (JAXB 3.x). Bumping only the pom property makes `BarBuilderIT` fail with `NoClassDefFoundError: jakarta/xml/bind/DataBindingException`: Tycho substitutes Maven-resolved dependencies with same-BSN target-platform bundles on the test classpath, so the old `jakarta.xml.bind-api 2.3.3` (which contains only `javax.xml.bind.*` classes) replaced the required 3.0.1.

## Transitive dependency audit (dependencyDepth=none)

The `BonitaArtifactsModels` target location resolves nothing transitively, so the explicit list was checked against all four 2.0.0 poms: their runtime dependencies are exactly the jakarta trio bumped here, plus `jackson-annotations` (already provided by the TP Jackson feature) and `lombok` (compile-only). `org.glassfish.hk2:osgi-resource-locator` is still required — `bonita-form-mapping-model` 2.0.0 declares it explicitly — so it stays at 2.4.0. No new runtime dependency is missing.

## Verification

- `./mvnw -f releng/target-platform/pom.xml validate -Pvalidate` → OK
- `./mvnw clean install` and `./mvnw -B -ntp verify -Pjacoco` (full reactor incl. the OSGi test fragments under tycho-surefire and the p2 site assembly) → BUILD SUCCESS
- Classpath audit of the failsafe run: no javax-era JAXB/activation jars remain
- p2 site metadata: `org.bonitasoft.artifacts.model.feature.feature.group` published with `range='[2.0.0,3.0.0)'`

## Note on CI

`ConnectorImplementationArtifactProviderTest.should_add_connector_in_bar` may fail with a `ReactorReader` NPE (`MavenSession.getProjects()` null) in the m2e embedded maven. This is a pre-existing flaky race, unrelated to this PR: the same signature failed on an unrelated dependabot branch on 2026-07-30 (run 30503013763), and identical cold CI runs of this branch both passed and failed with byte-identical logs. A follow-up issue will track the fix in `M2eMavenExecutor` (same area as #133). Beware: reruns of a failed job restore the failed run's saved `.m2` cache and are not independent samples.

## Release notes / downstream impact

`org.bonitasoft.bonita2bar` is published to Maven Central and re-exports engine types through its API: consumers inherit the `javax.xml.bind` → `jakarta.xml.bind` namespace change. This must be called out in the release notes, and the Bonita Studio target platform must move in lockstep with this bump.
