### PR TITLE
chore(deps): align the Jackson feature on 2.22.1

### DIFF
--- a/features/org.bonitasoft.bonita2bar.feature/feature.xml
+++ b/features/org.bonitasoft.bonita2bar.feature/feature.xml
@@ -34,7 +34,7 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
       <import feature="org.bonitasoft.bpm.model.feature" version="9.0.0" match="compatible"/>
       <import feature="org.bonitasoft.bonita2bpmn.feature" version="9.0.0" match="compatible"/>
       <import plugin="org.codehaus.groovy" version="3.0.0"/>
-      <import feature="com.fasterxml.jackson.feature" version="2.15.2.qualifier"/>
+      <import feature="com.fasterxml.jackson.feature" version="2.22.1" match="compatible"/>
       <import feature="org.bonitasoft.artifacts.model.feature" version="1.0.0.qualifier"/>
    </requires>
 

--- a/releng/target-platform/target-platform.target
+++ b/releng/target-platform/target-platform.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="platform" sequenceNumber="1744213320">
+<target name="platform" sequenceNumber="1744213321">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.equinox.sdk.feature.group" version="3.23.1400.v20240820-0604"/>
@@ -88,13 +88,13 @@ DynamicImport-Package: *
 ]]></instructions>
     </location>
     <location includeDependencyDepth="infinite" includeDependencyScopes="compile,runtime,system" includeSource="false" missingManifest="generate" type="Maven" label="MavenJackson">
-      <feature id="com.fasterxml.jackson.feature" label="Jackson Feature" provider-name="Bonitasoft S.A" version="2.18.3">
+      <feature id="com.fasterxml.jackson.feature" label="Jackson Feature" provider-name="Bonitasoft S.A" version="2.22.1">
       </feature>
       <dependencies>
         <dependency>
           <groupId>com.fasterxml.jackson.dataformat</groupId>
           <artifactId>jackson-dataformat-yaml</artifactId>
-          <version>2.18.3</version>
+          <version>2.22.1</version>
           <type>jar</type>
         </dependency>
       </dependencies>

--- a/releng/target-platform/target-platform.tpd
+++ b/releng/target-platform/target-platform.tpd
@@ -34,13 +34,13 @@ maven MavenJackson scope=compile,runtime,system dependencyDepth=infinite missing
     feature {
         id="com.fasterxml.jackson.feature"
         name="Jackson Feature"
-        version="2.18.3"
+        version="2.22.1"
         vendor="Bonitasoft S.A"
     }
     dependency {
         groupId="com.fasterxml.jackson.dataformat"
         artifactId="jackson-dataformat-yaml"
-        version="2.18.3"
+        version="2.22.1"
     }
 }
 maven BonitaArtifactsModels scope=compile,runtime,system dependencyDepth=none missingManifest=generate includeSources {


### PR DESCRIPTION
## What

Aligns the three Jackson version references that had drifted apart:

| Where | Before | After |
|---|---|---|
| root pom `jackson-bom` | 2.22.1 | 2.22.1 (unchanged - the aligned truth) |
| target platform `MavenJackson` location | 2.18.3 | **2.22.1** |
| `bonita2bar.feature` import | 2.15.2.qualifier | **2.22.1 match="compatible"** |

## Changes

- **Target platform** (`.tpd` + regenerated `.target`, sequenceNumber bumped): the Jackson feature and its `jackson-dataformat-yaml` source move to 2.22.1; `dependencyDepth=infinite` pulls core/databind/annotations transitively as before.
- **`bonita2bar.feature` import**: raised to `2.22.1` with an explicit `match="compatible"`, publishing a real `[2.22.1,3.0.0)` p2 requirement instead of the old 2.15.2 floor - same pattern #150 applied to the artifacts-model feature import, including the deliberate absence of a `.qualifier` suffix (`2.22.1.qualifier` would sort above the plain `2.22.1` feature and exclude it).

## Code impact

None. The Jackson surface in `org.bonitasoft.bonita2bar` is 6 classes of plain `ObjectMapper`/`YAMLFactory` databind + annotations - stable across the 2.x line - and the bundle `MANIFEST.MF` `Require-Bundle` entries carry no version ranges, so no manifest change is needed.

## Verification

- `./mvnw -f releng/target-platform/pom.xml validate -Pvalidate` -> OK
- Full reactor `verify` left to CI (the parameters-mapper tests and `BarBuilderIT` exercise the YAML round-trip, which is where any 2.18 -> 2.22 behavioral nuance from the embedded snakeyaml would surface)

## Note

Touches the same `.target`/`.tpd` files as #150 (different location blocks; only the `sequenceNumber` line will conflict - trivial to resolve for whichever merges second). The Jackson 2 -> 3 major (`tools.jackson` namespace) is deliberately out of scope: it should ride the Spring 7 / Boot 4 wave in lockstep with the engine.